### PR TITLE
Add exploit test command and update data structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ help:
 	@echo -e ""
 	@echo -e "  $(CYAN)make client-build$(RESET)           - Build the client"
 	@echo -e "  $(CYAN)make client-run$(RESET)             - Run the client"
+	@echo -e "  $(CYAN)make client-install$(RESET)         - Install the client"
 	@echo -e "  $(CYAN)make client-test$(RESET)            - Run client tests"
 	@echo -e "  $(CYAN)make client-install$(RESET)         - Install the client"
 	@echo -e "  $(CYAN)make client-clean$(RESET)           - Clean client build"
@@ -150,11 +151,11 @@ client-build-prod:
 client-run: client-build
 	@$(CLIENT_BIN_DIR)$(PATHSEP)$(CLIENT_BINARY_NAME)
 
+client-install: client-build
+	@sudo cp $(CLIENT_BIN_DIR)$(PATHSEP)$(CLIENT_BINARY_NAME) /usr/local/bin/$(CLIENT_BINARY_NAME)
+
 client-test:
 	@go test ./...
-
-client-install: client-build
-	@go install .
 
 # === SHARED TOOLS ===
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -74,15 +74,15 @@
 
 - [ ] Install cookieclient (binary) with pip @suga
 - [ ] Exploit test
-- [ ] Update data structure:
+- [x] Update data structure:
   1. Rename Flag struct to ClientData
   2. Add username, exploit name
   3. Addare nella config del server: ticktime, ad_start
-- [ ] Client update:
-  - [ ] Handle the stats that client sends to the server @akiidjk
-  - [ ] Add the Test command to the client (run the exploit only for the NOP team) @akiidjk
-    - [ ] Add in the Server Config (`config.yml`) the id of the NOP team @akiidjk
-    - [ ] Replace in the Server Config (`config.yml`) the 'my ip' with the id of the team NOT the ip address @akiidjk
+- [x] Client update:
+  - [x] Handle the stats that client sends to the server @akiidjk
+  - [x] Add the Test command to the client (run the exploit only for the NOP team) @akiidjk
+    - [x] Add in the Server Config (`config.yml`) the id of the NOP team @akiidjk
+    - [x] Replace in the Server Config (`config.yml`) the 'my ip' with the id of the team NOT the ip address @akiidjk
 - [ ] Design con shadcnui @suga
   - [ ] Tutorial nella dashboard @suga
   - [ ] Possibilità di scaricare dal server il client @suga -> dependes on (Tutorial nella dashboard @suga)

--- a/NOTES.md
+++ b/NOTES.md
@@ -73,7 +73,7 @@
 ## RELEASE 1.2
 
 - [ ] Install cookieclient (binary) with pip @suga
-- [ ] Exploit test
+- [x] Exploit test
 - [x] Update data structure:
   1. Rename Flag struct to ClientData
   2. Add username, exploit name

--- a/cmd/client/cmd/exploit.go
+++ b/cmd/client/cmd/exploit.go
@@ -31,6 +31,14 @@ var runCmd = &cobra.Command{
 	Run:   run,
 }
 
+// runCmd represents the run exploit command
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test the exploit on the NOP team",
+	Long:  `This command allows you to test an exploit against the NOP team to verify it works correctly before running it against other teams in the competition.`,
+	Run:   test,
+}
+
 // createCmd represents the create exploit command
 var createCmd = &cobra.Command{
 	Use:   "create",
@@ -80,6 +88,7 @@ func init() {
 
 	// Add all subcommands to ExploitCmd
 	ExploitCmd.AddCommand(runCmd)
+	ExploitCmd.AddCommand(testCmd)
 	ExploitCmd.AddCommand(createCmd)
 	ExploitCmd.AddCommand(stopCmd)
 	ExploitCmd.AddCommand(listCmd)
@@ -95,6 +104,16 @@ func init() {
 	runCmd.MarkFlagRequired("password")
 	runCmd.MarkFlagRequired("port")
 	runCmd.MarkFlagRequired("host")
+
+	testCmd.Flags().StringVarP(&exploitPath, "exploit", "e", "", "Path to the exploit file to execute")
+	testCmd.Flags().Uint16VarP(&servicePort, "port", "p", 0, "Service Port to attack")
+	testCmd.Flags().BoolVarP(&detach, "detach", "d", false, "Run the exploit in the background (detached mode)")
+	testCmd.Flags().IntVarP(&tickTime, "tick", "t", 120, "Interval in seconds between exploit executions")
+	testCmd.Flags().IntVarP(&threadCount, "thread", "T", 5, "Number of concurrent threads to run the exploit with")
+	testCmd.MarkFlagRequired("exploit")
+	testCmd.MarkFlagRequired("password")
+	testCmd.MarkFlagRequired("port")
+	testCmd.MarkFlagRequired("host")
 
 	// Setup flags for createCmd
 	createCmd.Flags().StringVarP(&exploitName, "name", "n", "", "Name of the exploit template")
@@ -151,7 +170,75 @@ func run(cmd *cobra.Command, args []string) {
 
 	logger.Log.Info().Msg("Client initialized successfully")
 
-	result, err := exploit.Start(cm.GetArgsAttackInstance().ExploitPath, tickTime, threadCount, servicePort)
+	result, err := exploit.Start(cm.GetArgsAttackInstance().ExploitPath, tickTime, threadCount, servicePort, false)
+	if err != nil {
+		logger.Log.Fatal().Err(err).Msg("Failed to execute exploit")
+	}
+
+	exploitS := config.Exploit{
+		Name: exploitPath,
+		PID:  result.Cmd.Process.Pid,
+	}
+	localConfig := cm.GetLocalConfig()
+	localConfig.Exploits = append(localConfig.Exploits, exploitS)
+	cm.SetLocalConfig(localConfig)
+	if err := cm.WriteLocalConfigToFile(); err != nil {
+		logger.Log.Fatal().Err(err).Msg("Failed to write configuration with new exploit")
+	}
+	cm.SetPID(result.Cmd.Process.Pid)
+	logger.Log.Info().Msg("Exploit started successfully")
+
+	websockets.OnNewConfig = func() {
+		exploit.RestartGlobal()
+	}
+
+	go websockets.Start(result.FlagsChan)
+
+	if err := result.Cmd.Wait(); err != nil {
+		logger.Log.Error().Err(err).Msg("Exploit process exited with error")
+	}
+}
+
+func test(cmd *cobra.Command, args []string) {
+	cm := config.GetConfigManager()
+	cm.SetArgsAttackInstance(config.ArgsAttack{
+		ServicePort: servicePort,
+		TickTime:    tickTime,
+		ThreadCount: threadCount,
+		Detach:      detach,
+		ExploitPath: exploitPath,
+	})
+	logger.Log.Debug().Str("ExploitPath", cm.GetArgsAttackInstance().ExploitPath).
+		Int("TickTime", cm.GetArgsAttackInstance().TickTime).
+		Int("ThreadCount", cm.GetArgsAttackInstance().ThreadCount).
+		Uint16("ServicePort", cm.GetArgsAttackInstance().ServicePort).
+		Msg("Starting exploit execution with parameters")
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		logger.Log.Info().Msg("Shutting down gracefully...")
+		if cm.GetPID() != 0 {
+			exploit.Cleanup(cm.GetPID())
+		}
+		os.Exit(0)
+	}()
+
+	if err := exploit.Setup(detach); err != nil {
+		if logger.LogLevel != zerolog.Disabled {
+			logger.Log.Fatal().Err(err).Msg("Initialization error")
+			logger.Close()
+		} else {
+			fmt.Println("Error initializing:", err)
+		}
+		os.Exit(1)
+	}
+	defer logger.Close()
+
+	logger.Log.Info().Msg("Client initialized successfully")
+
+	result, err := exploit.Start(cm.GetArgsAttackInstance().ExploitPath, tickTime, threadCount, servicePort, true)
 	if err != nil {
 		logger.Log.Fatal().Err(err).Msg("Failed to execute exploit")
 	}

--- a/config.yml
+++ b/config.yml
@@ -6,13 +6,15 @@ server:
   submit_flag_checker_time: 120
   max_flag_batch_size: 1000
   protocol: "cc_http"
+  tick_time: 120
+  start_time: "idk"
 
 client:
   services:
     - name: "CookieService"
       port: 8081
-
   range_ip_teams: 29
   format_ip_teams: "10.10.{}.1"
-  my_team_ip: "10.10.0.1"
+  my_team_id: 1
   regex_flag: "[A-Z0-9]{31}="
+  nop_team: 0

--- a/internal/client/exploit/exploit.go
+++ b/internal/client/exploit/exploit.go
@@ -33,7 +33,7 @@ type StreamingResult struct {
 // ============================================================================
 
 // Run executes the exploit with the given parameters and returns a StreamingResult
-func Run(exploitPath string, tickTime int, threads int, servicePort uint16) (*StreamingResult, error) {
+func Run(exploitPath string, tickTime int, threads int, servicePort uint16, test bool) (*StreamingResult, error) {
 	cm := config.GetConfigManager()
 	cm.SetArgsAttackInstance(config.ArgsAttack{
 		ExploitPath: exploitPath,
@@ -76,6 +76,7 @@ func Run(exploitPath string, tickTime int, threads int, servicePort uint16) (*St
 		tickTime,
 		threads,
 		servicePort,
+		test,
 	)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Failed to execute exploit")

--- a/internal/client/exploit/parse.go
+++ b/internal/client/exploit/parse.go
@@ -4,6 +4,7 @@ package exploit
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ByteTheCookies/CookieFarm/internal/client/config"
@@ -23,35 +24,58 @@ type ParsedFlagOutput struct {
 	Message     string `json:"message"`      // Additional message or error information
 }
 
-// ParseLine parses a JSON line into a Flag struct.
-func ParseLine(line string) (models.Flag, string, error) {
-	cm := config.GetConfigManager()
-	var out ParsedFlagOutput
-	if err := json.Unmarshal([]byte(line), &out); err != nil {
-		return models.Flag{}, "invalid", fmt.Errorf("invalid JSON format: %w", err)
-	}
+type StatusBatchOutput struct {
+	Status      string `json:"status"`       // Status of the flag submission (eg "success", "failed", "error", "fatal")
+	Message     string `json:"message"`      // Additional message or error information
+	NameService string `json:"name_service"` // Human-readable name of the service
+	PortService uint16 `json:"port_service"` // Port of the service that produced the flag
+	TotalFlag   int    `json:"total_flag"`   // Total flag collected in the batch
+	SuccessTeam int    `json:"success_team"` // Total number of teams from which flags were successfully extracted
+	FailedTeam  int    `json:"failed_team"`  // Total number of teams from which flag extraction failed
+}
 
-	switch out.Status {
-	case "info":
-		return models.Flag{}, out.Status, errors.New(out.Message)
-	case "failed":
-		return models.Flag{}, out.Status, fmt.Errorf("flag submission failed for team %d on the %s: %s",
-			out.TeamID, cm.MapPortToService(out.PortService), out.Message)
-	case "error":
-		return models.Flag{}, out.Status, fmt.Errorf("flag submission error: %s", out.Message)
-	case "fatal":
-		return models.Flag{}, out.Status, fmt.Errorf("fatal error in the exploiter: %s", out.Message)
-	case "success":
-		return models.Flag{
-			FlagCode:     out.FlagCode,
-			ServiceName:  out.NameService,
-			PortService:  out.PortService,
-			SubmitTime:   uint64(time.Now().Unix()),
-			ResponseTime: 0,
-			Status:       "UNSUBMITTED",
-			TeamID:       out.TeamID,
-		}, out.Status, nil
-	default:
-		return models.Flag{}, "unknown", fmt.Errorf("unhandled status: %s", out.Status)
+// ParseLine parses a JSON line into a Flag struct.
+func ParseLine(line string) (models.ClientData, string, error) {
+	cm := config.GetConfigManager()
+
+	if strings.Contains(line, "stats") {
+		var out StatusBatchOutput
+		if err := json.Unmarshal([]byte(line), &out); err != nil {
+			return models.ClientData{}, "invalid", fmt.Errorf("invalid JSON format: %w", err)
+		}
+
+		statusMessage := fmt.Sprintf("Service: %s (Port: %d) - Total Flags: %d - Success Teams: %d - Failed Teams: %d - Message: %s",
+			out.NameService, out.PortService, out.TotalFlag, out.SuccessTeam, out.FailedTeam, out.Message)
+
+		return models.ClientData{}, out.Status, errors.New(statusMessage)
+	} else {
+		var out ParsedFlagOutput
+		if err := json.Unmarshal([]byte(line), &out); err != nil {
+			return models.ClientData{}, "invalid", fmt.Errorf("invalid JSON format: %w", err)
+		}
+
+		switch out.Status {
+		case "info":
+			return models.ClientData{}, out.Status, errors.New(out.Message)
+		case "failed":
+			return models.ClientData{}, out.Status, fmt.Errorf("flag submission failed for team %d on the %s: %s",
+				out.TeamID, cm.MapPortToService(out.PortService), out.Message)
+		case "error":
+			return models.ClientData{}, out.Status, fmt.Errorf("flag submission error: %s", out.Message)
+		case "fatal":
+			return models.ClientData{}, out.Status, fmt.Errorf("fatal error in the exploiter: %s", out.Message)
+		case "success":
+			return models.ClientData{
+				FlagCode:     out.FlagCode,
+				ServiceName:  out.NameService,
+				PortService:  out.PortService,
+				SubmitTime:   uint64(time.Now().Unix()),
+				ResponseTime: 0,
+				Status:       "UNSUBMITTED",
+				TeamID:       out.TeamID,
+			}, out.Status, nil
+		default:
+			return models.ClientData{}, "unknown", fmt.Errorf("unhandled status: %s", out.Status)
+		}
 	}
 }

--- a/internal/client/exploit/run.go
+++ b/internal/client/exploit/run.go
@@ -18,7 +18,7 @@ import (
 
 type ExecutionResult struct {
 	Cmd        *exec.Cmd
-	FlagsChan  chan models.Flag
+	FlagsChan  chan models.ClientData
 	OutputChan chan string
 	stopReader chan struct{}
 	done       chan struct{}
@@ -30,7 +30,7 @@ var (
 )
 
 // Start starts the exploit_manager and listens for flags in stdout.
-func Start(exploitPath string, tickTime int, threadCount int, port uint16) (*ExecutionResult, error) {
+func Start(exploitPath string, tickTime int, threadCount int, port uint16, test bool) (*ExecutionResult, error) {
 	cm := config.GetConfigManager()
 	logger.Log.Debug().
 		Str("exploitPath", exploitPath).
@@ -40,34 +40,24 @@ func Start(exploitPath string, tickTime int, threadCount int, port uint16) (*Exe
 		Str("Host", cm.GetLocalConfig().Host+":"+strconv.Itoa(int(cm.GetLocalConfig().Port))).
 		Msg("Starting exploit with parameters")
 	var cmd *exec.Cmd
+	var args []string
+
+	if test {
+		args = append(args, exploitPath, "-s", cm.GetLocalConfig().Host+":"+strconv.Itoa(int(cm.GetLocalConfig().Port)), "-t", strconv.Itoa(tickTime), "-T", strconv.Itoa(threadCount), "-p", strconv.Itoa(int(port)), "-n", cm.MapPortToService(port), "-x")
+	} else {
+		args = append(args, exploitPath, "-s", cm.GetLocalConfig().Host+":"+strconv.Itoa(int(cm.GetLocalConfig().Port)), "-t", strconv.Itoa(tickTime), "-T", strconv.Itoa(threadCount), "-p", strconv.Itoa(int(port)), "-n", cm.MapPortToService(port))
+	}
+
 	if runtime.GOOS == "windows" {
 		cmd = exec.Command(
 			"python",
-			exploitPath,
-			"-s",
-			cm.GetLocalConfig().Host+":"+strconv.Itoa(int(cm.GetLocalConfig().Port)),
-			"-t",
-			strconv.Itoa(tickTime),
-			"-T",
-			strconv.Itoa(threadCount),
-			"-p",
-			strconv.Itoa(int(port)),
-			"-n",
-			cm.MapPortToService(port),
+			args...,
 		)
 	} else {
+		logger.Log.Debug().Msgf("args: %v", args[1:])
 		cmd = exec.Command(
 			exploitPath,
-			"-s",
-			cm.GetLocalConfig().Host+":"+strconv.Itoa(int(cm.GetLocalConfig().Port)),
-			"-t",
-			strconv.Itoa(tickTime),
-			"-T",
-			strconv.Itoa(threadCount),
-			"-p",
-			strconv.Itoa(int(port)),
-			"-n",
-			cm.MapPortToService(port),
+			args[1:]...,
 		)
 	}
 
@@ -92,7 +82,7 @@ func Start(exploitPath string, tickTime int, threadCount int, port uint16) (*Exe
 		return nil, fmt.Errorf("failed to start command: %w", err)
 	}
 
-	flagsChan := make(chan models.Flag, 500)
+	flagsChan := make(chan models.ClientData, 500)
 	outputChan := make(chan string, 100) // Buffer for real-time output
 	stopReader := make(chan struct{})
 	done := make(chan struct{})
@@ -126,6 +116,7 @@ func RestartGlobal() {
 		cm.GetArgsAttackInstance().TickTime,
 		cm.GetArgsAttackInstance().ThreadCount,
 		cm.GetArgsAttackInstance().ServicePort,
+		false,
 	)
 	if err != nil {
 		logger.Log.Fatal().Err(err).Msg("Failed to start new exploit")
@@ -176,6 +167,8 @@ func logParsedLineError(err error, status, line string) {
 		logger.Log.Warn().Err(err).Msg("Failed to run exploit")
 	case "error":
 		logger.Log.Error().Err(err).Msg("Failed to run exploit")
+	case "stats":
+		logger.Log.Info().Msg(err.Error())
 	default:
 		logger.Log.Debug().Err(err).Msg("Parsing warning")
 	}
@@ -183,7 +176,7 @@ func logParsedLineError(err error, status, line string) {
 }
 
 // Read the stdout and parse JSON lines into Flag structs.
-func readStdout(stdout io.Reader, flagsChan chan<- models.Flag, outputChan chan<- string, stop <-chan struct{}, done chan<- struct{}) {
+func readStdout(stdout io.Reader, flagsChan chan<- models.ClientData, outputChan chan<- string, stop <-chan struct{}, done chan<- struct{}) {
 	defer func() { done <- struct{}{} }()
 
 	scanner := bufio.NewScanner(stdout)

--- a/internal/client/tui/forms.go
+++ b/internal/client/tui/forms.go
@@ -25,7 +25,7 @@ func CreateForm(command string) ([]textinput.Model, []string) {
 		inputs, labels = createLoginForm()
 	case "config update":
 		inputs, labels = createConfigUpdateForm()
-	case "exploit run":
+	case "exploit run", "exploit test":
 		inputs, labels = createExploitRunForm()
 	case "exploit create", "exploit remove":
 		inputs, labels = createExploitNameForm()
@@ -185,7 +185,7 @@ func ValidateForm(command string, inputs []textinput.Model) error {
 		return validateLoginForm(inputs)
 	case "config update":
 		return validateConfigUpdateForm(inputs)
-	case "exploit run":
+	case "exploit run", "exploit test":
 		return validateExploitRunForm(inputs)
 	case "exploit create", "exploit remove":
 		return validateExploitNameForm(inputs)

--- a/internal/client/tui/handlers.go
+++ b/internal/client/tui/handlers.go
@@ -86,6 +86,8 @@ func (h *CommandHandler) executeFormCommand(command string, formData *FormData) 
 				output, err = h.handleConfigUpdate(formData)
 			case "exploit run":
 				output, err = h.handleExploitRun(formData)
+			case "exploit test":
+				output, err = h.handleExploitTest(formData)
 			case "exploit create":
 				output, err = h.handleExploitCreate(formData)
 			case "exploit remove":
@@ -139,6 +141,20 @@ func (h *CommandHandler) handleExploitRun(formData *FormData) (string, error) {
 	}
 
 	return h.cmdRunner.ExecuteExploitRun(exploitPath, servicePort, tickTime, threadCount)
+}
+
+// handleExploitRun processes exploit test command
+func (h *CommandHandler) handleExploitTest(formData *FormData) (string, error) {
+	exploitPath := formData.Fields["Exploit Path"]
+	servicePort := formData.Fields["Service Port"]
+	tickTime := formData.Fields["Tick Time (seconds)"]
+	threadCount := formData.Fields["Thread Count"]
+
+	if exploitPath == "" || servicePort == "" {
+		return "", errors.New("exploit path and service port are required")
+	}
+
+	return h.cmdRunner.ExecuteExploitTest(exploitPath, servicePort, tickTime, threadCount)
 }
 
 // handleExploitCreate processes exploit create command

--- a/internal/client/tui/menu.go
+++ b/internal/client/tui/menu.go
@@ -58,6 +58,7 @@ func createConfigMenu() list.Model {
 func createExploitMenu() list.Model {
 	exploitMenuItems := []list.Item{
 		menuItem{title: "Run Exploit", description: "Run an exploit against other teams", command: "exploit run"},
+		menuItem{title: "Test Exploit", description: "Test an exploit on the nop team", command: "exploit test"},
 		menuItem{title: "Create Exploit", description: "Create a new exploit template", command: "exploit create"},
 		menuItem{title: "List Exploits", description: "List all running exploits", command: "exploit list"},
 		menuItem{title: "Stop Exploit", description: "Stop a running exploit", command: "exploit stop"},
@@ -126,7 +127,7 @@ func IsDirectCommand(command string) bool {
 // RequiresInput checks if the command requires user input
 func RequiresInput(command string) bool {
 	switch command {
-	case "config login", "config update", "exploit run", "exploit create", "exploit remove", "exploit stop":
+	case "config login", "config update", "exploit run", "exploit create", "exploit remove", "exploit stop", "exploit test":
 		return true
 	default:
 		return false

--- a/internal/client/websockets/submitter.go
+++ b/internal/client/websockets/submitter.go
@@ -14,12 +14,12 @@ type EventWS struct {
 }
 
 type EventWSFlag struct {
-	Type    string      `json:"type"`
-	Payload models.Flag `json:"payload"`
+	Type    string            `json:"type"`
+	Payload models.ClientData `json:"payload"`
 }
 
 // Start initializes the submission loop to the cookiefarm server.
-func Start(flagsChan <-chan models.Flag) error {
+func Start(flagsChan <-chan models.ClientData) error {
 	logger.Log.Info().Msg("Starting submission loop to the cookiefarm server...")
 	conn, err := GetConnection()
 	if err != nil {

--- a/internal/server/server/handler_api.go
+++ b/internal/server/server/handler_api.go
@@ -29,7 +29,7 @@ func HandleGetAllFlags(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(ResponseError{Error: err.Error()})
 	}
 	if flags == nil {
-		flags = []models.Flag{}
+		flags = []models.ClientData{}
 	}
 	data := ResponseFlags{
 		Nflags: len(flags),
@@ -67,7 +67,7 @@ func HandleGetPaginatedFlags(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(ResponseError{Error: err.Error()})
 	}
 	if flags == nil {
-		flags = []models.Flag{}
+		flags = []models.ClientData{}
 	}
 	return c.JSON(ResponseFlags{
 		Nflags: len(flags),

--- a/internal/server/server/types.go
+++ b/internal/server/server/types.go
@@ -6,8 +6,8 @@ import (
 
 // ResponseFlags represents the response for the flags api
 type ResponseFlags struct {
-	Nflags int           `json:"n_flags"`
-	Flags  []models.Flag `json:"flags"`
+	Nflags int                 `json:"n_flags"`
+	Flags  []models.ClientData `json:"flags"`
 }
 
 // SigninRequest from the client to the server
@@ -38,7 +38,7 @@ type ViewParamsPagination struct {
 
 // ViewParamsFlags represents the parameters for the flags view
 type ViewParamsFlags struct {
-	Flags []models.Flag `json:"flags"` // List of flags to display
+	Flags []models.ClientData `json:"flags"` // List of flags to display
 }
 
 // ResponseSuccess represents the response for the success api
@@ -54,10 +54,10 @@ type ResponseError struct {
 
 // SubmitFlagRequest the struct for the requests from the client to server
 type SubmitFlagRequest struct {
-	Flag models.Flag `json:"flag"` // Flag to submit
+	Flag models.ClientData `json:"flag"` // Flag to submit
 }
 
 // SubmitFlagsRequest the struct for the requests from the client to server
 type SubmitFlagsRequest struct {
-	Flags []models.Flag `json:"flags"` // Flags to submit
+	Flags []models.ClientData `json:"flags"` // Flags to submit
 }

--- a/internal/server/sqlite/flag_collector.go
+++ b/internal/server/sqlite/flag_collector.go
@@ -17,13 +17,13 @@ const (
 
 // FlagCollector manages the collection and flushing of flags to the database
 type FlagCollector struct {
-	buffer     []models.Flag  // Buffer for storing flags
-	mutex      sync.Mutex     // Mutex for thread-safe access
-	flushTimer *time.Timer    // Timer for periodic flushing
-	stopChan   chan struct{}  // Channel to signal stop
-	running    bool           // Indicates if the collector is running
-	flushCond  *sync.Cond     // Condition variable for flushing
-	stats      CollectorStats // Statistics about the collector
+	buffer     []models.ClientData // Buffer for storing flags
+	mutex      sync.Mutex          // Mutex for thread-safe access
+	flushTimer *time.Timer         // Timer for periodic flushing
+	stopChan   chan struct{}       // Channel to signal stop
+	running    bool                // Indicates if the collector is running
+	flushCond  *sync.Cond          // Condition variable for flushing
+	stats      CollectorStats      // Statistics about the collector
 }
 
 // CollectorStats holds statistics about the flag collector
@@ -48,7 +48,7 @@ var (
 func GetCollector() *FlagCollector {
 	once.Do(func() {
 		c := &FlagCollector{
-			buffer:   make([]models.Flag, 0, maxBufferSize),
+			buffer:   make([]models.ClientData, 0, maxBufferSize),
 			stopChan: make(chan struct{}),
 		}
 		c.flushCond = sync.NewCond(&c.mutex)
@@ -136,7 +136,7 @@ func (fc *FlagCollector) Stop() error {
 }
 
 // AddFlag adds a flag to the collector's buffer
-func (fc *FlagCollector) AddFlag(flag models.Flag) error {
+func (fc *FlagCollector) AddFlag(flag models.ClientData) error {
 	fc.mutex.Lock()
 	defer fc.mutex.Unlock()
 
@@ -155,7 +155,7 @@ func (fc *FlagCollector) AddFlag(flag models.Flag) error {
 
 	if len(fc.buffer) >= maxBufferSize {
 		logger.Log.Debug().Msg("Flushing flag buffer due to size limit")
-		flagsToInsert := make([]models.Flag, len(fc.buffer))
+		flagsToInsert := make([]models.ClientData, len(fc.buffer))
 		copy(flagsToInsert, fc.buffer)
 		fc.buffer = fc.buffer[:0]
 
@@ -195,7 +195,7 @@ func (fc *FlagCollector) FlushWithContext(ctx context.Context) error {
 		return nil
 	}
 
-	flagsToInsert := make([]models.Flag, len(fc.buffer))
+	flagsToInsert := make([]models.ClientData, len(fc.buffer))
 	copy(flagsToInsert, fc.buffer)
 	fc.buffer = fc.buffer[:0]
 

--- a/internal/server/sqlite/insert.go
+++ b/internal/server/sqlite/insert.go
@@ -11,7 +11,7 @@ import (
 
 // AddFlagsWithContext adds a batch of flags to the database with a custom context.
 // It divides the flags into batches to insert in chunks, helping avoid hitting query parameter limits.
-func AddFlagsWithContext(ctx context.Context, flags []models.Flag) error {
+func AddFlagsWithContext(ctx context.Context, flags []models.ClientData) error {
 	if len(flags) == 0 {
 		return nil
 	}
@@ -55,7 +55,7 @@ func AddFlagsWithContext(ctx context.Context, flags []models.Flag) error {
 
 // AddFlags adds a batch of flags to the database with a default timeout.
 // It calls AddFlagsWithContext with a timeout context.
-func AddFlags(flags []models.Flag) error {
+func AddFlags(flags []models.ClientData) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	return AddFlagsWithContext(ctx, flags)
@@ -63,11 +63,11 @@ func AddFlags(flags []models.Flag) error {
 
 // AddFlag adds a single flag to the database.
 // It calls the AddFlags function to add the flag as a batch of size 1.
-func AddFlag(flag models.Flag) error {
-	return AddFlags([]models.Flag{flag})
+func AddFlag(flag models.ClientData) error {
+	return AddFlags([]models.ClientData{flag})
 }
 
 // AddFlagWithContext adds a single flag to the database with a custom context.
-func AddFlagWithContext(ctx context.Context, flag models.Flag) error {
-	return AddFlagsWithContext(ctx, []models.Flag{flag})
+func AddFlagWithContext(ctx context.Context, flag models.ClientData) error {
+	return AddFlagsWithContext(ctx, []models.ClientData{flag})
 }

--- a/internal/server/sqlite/schema.sql
+++ b/internal/server/sqlite/schema.sql
@@ -6,7 +6,9 @@ CREATE TABLE IF NOT EXISTS flags (
     response_time INTEGER, -- Unix timestamp
     msg VARCHAR(255) NOT NULL DEFAULT '',
     status VARCHAR(255) NOT NULL,
-    team_id INTEGER NOT NULL
+    team_id INTEGER NOT NULL,
+    username VARCHAR(255) NOT NULL DEFAULT '',
+    exploit_name VARCHAR(255) NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_flags_submit_time

--- a/internal/server/sqlite/select.go
+++ b/internal/server/sqlite/select.go
@@ -25,22 +25,22 @@ const (
 // --------- Flag Structs ---------
 
 // GetAllFlags retrieves all flags from the database.
-func GetAllFlags() ([]models.Flag, error) {
+func GetAllFlags() ([]models.ClientData, error) {
 	return queryFlags(queryAllFlags)
 }
 
 // GetUnsubmittedFlags retrieves the first n unsubmitted flags from the database.
-func GetUnsubmittedFlags(limit uint) ([]models.Flag, error) {
+func GetUnsubmittedFlags(limit uint) ([]models.ClientData, error) {
 	return queryFlags(queryUnsubmittedFlags, limit)
 }
 
 // GetFirstNFlags retrieves the first n flags from the database.
-func GetFirstNFlags(limit uint) ([]models.Flag, error) {
+func GetFirstNFlags(limit uint) ([]models.ClientData, error) {
 	return queryFlags(queryFirstNFlags, limit)
 }
 
 // GetPagedFlags retrieves the flags from the database starting at the given offset.
-func GetPagedFlags(limit, offset uint) ([]models.Flag, error) {
+func GetPagedFlags(limit, offset uint) ([]models.ClientData, error) {
 	return queryFlags(queryPagedFlags, limit, offset)
 }
 
@@ -70,7 +70,7 @@ func GetPagedFlagCodeList(limit, offset uint) ([]string, error) {
 
 // queryFlags executes a query to retrieve flags from the database.
 // It prepares and executes a query with the provided arguments and returns a list of flags.
-func queryFlags(query string, args ...any) ([]models.Flag, error) {
+func queryFlags(query string, args ...any) ([]models.ClientData, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -88,8 +88,8 @@ func queryFlags(query string, args ...any) ([]models.Flag, error) {
 	}
 	defer rows.Close()
 
-	var flags []models.Flag
-	flagPtr := new(models.Flag)
+	var flags []models.ClientData
+	flagPtr := new(models.ClientData)
 	for rows.Next() {
 		if err := rows.Scan(
 			&flagPtr.FlagCode, &flagPtr.ServiceName, &flagPtr.PortService,

--- a/internal/server/websockets/event.go
+++ b/internal/server/websockets/event.go
@@ -23,7 +23,7 @@ func init() {
 
 // FlagHandler will send out a message to all other participants in the chat
 func FlagHandler(event Event, client *Client) error {
-	var flag models.Flag
+	var flag models.ClientData
 	if err := json.Unmarshal(event.Payload, &flag); err != nil {
 		return fmt.Errorf("bad payload in request: %v", err)
 	}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -13,15 +13,18 @@ type ConfigServer struct {
 	HostFlagchecker       string `json:"host_flagchecker" yaml:"host_flagchecker"`                 // Address of the flagchecker server
 	TeamToken             string `json:"team_token" yaml:"team_token"`                             // Authentication token for team identity
 	Protocol              string `json:"protocol" yaml:"protocol"`                                 // Protocol used to communicate with the flagchecker server
+	TickTime              int    `json:"tick_time" yaml:"tick_time"`                               // Duration of one game tick in seconds
+	StartTime             string `json:"start_time" yaml:"start_time"`                             // CTF competition start time (ISO 8601 format)
 }
 
 // ConfigClient contains all client-side configuration options.
 type ConfigClient struct {
 	RegexFlag     string    `json:"regex_flag" yaml:"regex_flag"`           // Regex used to identify flags in output
 	FormatIPTeams string    `json:"format_ip_teams" yaml:"format_ip_teams"` // Format string for generating team IPs
-	MyTeamIP      string    `json:"my_team_ip" yaml:"my_team_ip"`           // IP address of the current team
+	MyTeamID      string    `json:"my_team_id" yaml:"my_team_id"`           // ID of the current team
 	Services      []Service `json:"services" yaml:"services"`               // List of services to exploit
 	RangeIPTeams  uint8     `json:"range_ip_teams" yaml:"range_ip_teams"`   // Number of teams / IP range
+	NOPTeam       int       `json:"nop_team" yaml:"nop_team"`               // The id of the nop team in the ctf
 }
 
 // ConfigShared aggregates both server and client configuration,
@@ -39,14 +42,16 @@ const (
 	StatusError       = "ERROR"       // Status for error flags
 )
 
-// Flag represents a single flag captured during a CTF round.
+// ClientData represents a single flag captured during a CTF round.
 // It includes metadata about the submission and the service context.
-type Flag struct {
+type ClientData struct {
 	SubmitTime   uint64 `json:"submit_time"`   // UNIX timestamp when the flag was submitted
 	ResponseTime uint64 `json:"response_time"` // UNIX timestamp when a response was received
 	FlagCode     string `json:"flag_code"`     // Actual flag string
 	ServiceName  string `json:"service_name"`  // Human-readable name of the service
 	Status       string `json:"status"`        // Status of the submission (e.g., "unsubmitted", "accepted", "denied")
+	Username     string `json:"username"`      // Username of client
+	ExploitName  string `json:"exploit_name"`  // Name of the exploit
 	Msg          string `json:"msg"`           // Message from the flag checker service
 	PortService  uint16 `json:"port_service"`  // Port of the vulnerable service
 	TeamID       uint16 `json:"team_id"`       // ID of the team the flag was captured from


### PR DESCRIPTION
Implement an "exploit test" command to run exploits against the NOP team, renaming the Flag struct to ClientData and updating all references. Enhance the database schema to include username and exploit_name fields, and modify the configuration to use team IDs instead of IP addresses. Adjust the TUI and command handling to accommodate the new test command and update the Makefile accordingly. Document these changes in NOTES.md.