### PR TITLE
Refactor configuration handling to use boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Make sure you have the following installed:
       # Server configuration
       DEBUG=false                   # Enable debug mode for verbose logging
       PASSWORD=SuperSecret  # Set a strong password for authentication
-      CONFIG_FROM_FILE=config.yml  # Set if the server takes the config from config.yml in the filesystem; otherwise, do not set the variable
+      CONFIG_FILE=true  # Set if the server takes the config from config.yml in the filesystem; otherwise, do not set the variable
       PORT=8080            # Define the port the server will listen on
     ```
 

--- a/cmd/server/cmd/root.go
+++ b/cmd/server/cmd/root.go
@@ -62,7 +62,7 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "Enable debug logging")
-	RootCmd.PersistentFlags().StringVarP(&config.ConfigPath, "config", "c", "", "Path to the configuration file")
+	RootCmd.PersistentFlags().BoolVarP(&config.ConfigFile, "config", "c", false, "Use configuration file instead of web config")
 	RootCmd.PersistentFlags().StringVarP(&config.Password, "password", "p", "password", "Password for authentication")
 	RootCmd.PersistentFlags().StringVarP(&config.ServerPort, "port", "P", "8080", "Port for server")
 
@@ -85,7 +85,7 @@ func Run(cmd *cobra.Command, args []string) {
 	logger.Setup(level, false)
 	defer logger.Close()
 
-	if config.ConfigPath != "" {
+	if config.ConfigFile {
 		logger.Log.Info().Msg("Using file config...")
 		err := core.LoadConfig(config.ConfigPath)
 		if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ${PORT}:${PORT}
     environment:
       PASSWORD: ${PASSWORD}
-      CONFIG_FROM_FILE: ${CONFIG_FROM_FILE}
+      CONFIG_FILE: ${CONFIG_FILE}
       PORT: ${PORT}
       DEBUG: ${DEBUG}
     volumes:

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -10,7 +10,7 @@ var SharedConfig models.ConfigShared // Initialize the config struct
 
 var (
 	Debug      bool                                                                 // Global debug flag
-	ConfigPath string                                                               // Path to configuration file
+	ConfigFile bool                                                                 // Use configuration file instead of web config
 	Password   string                                                               // Password for authentication
 	ServerPort string                                                               // Port for server
 	Secret     = make([]byte, 32)                                                   // JWT secret key
@@ -19,6 +19,7 @@ var (
 )
 
 const (
-	DefaultLimit  int = 100 // Default maximum number of flags to retrieve in the view
-	DefaultOffset int = 0   // Default offset for pagination
+	ConfigPath    string = "config.yml" // Path to configuration file
+	DefaultLimit  int    = 100          // Default maximum number of flags to retrieve in the view
+	DefaultOffset int    = 0            // Default offset for pagination
 )

--- a/run.sh
+++ b/run.sh
@@ -8,8 +8,8 @@ CMD="/app/bin/cks"
 CMD="$CMD -p \"$PASSWORD\""
 CMD="$CMD -P \"$PORT\""
 
-if [ -n "$CONFIG_FROM_FILE" ]; then
-    CMD="$CMD -c \"$CONFIG_FROM_FILE\""
+if [ -n "$CONFIG_FILE" ]; then
+    CMD="$CMD -c"
 fi
 
 if [ "$DEBUG" = "true" ]; then


### PR DESCRIPTION
Change the configuration handling to use a boolean flag for determining if the server should load settings from a configuration file, simplifying the environment variable setup.

Fixed issue #123 