### PR TITLE
Add paginated flag logs table with advanced filtering

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,11 +1,12 @@
 root = "."
+
 testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
 exclude_dir = ["tmp", "vendor", "testdata", "node_modules"]
 args_bin = []
-bin = "./bin/cks -c ./config.yml --debug"
+bin = "./bin/cks -c --debug"
 cmd = "make minify; make server-build"
 delay = 1000
 exclude_file = ["internal/server/public/js/output.min.js"]

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,26 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
+        "tailwindcss-animate": "^1.0.7",
+      },
+    },
+  },
+  "packages": {
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
+
+    "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+
+    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+
+    "tailwindcss": ["tailwindcss@4.1.11", "", {}, "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA=="],
+
+    "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
+  }
+}

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ server:
   max_flag_batch_size: 1000
   protocol: "cc_http"
   tick_time: 120
-  flag_ttl: 5 # in ticks
+  flag_ttl: 0 # in ticks
   start_time: "2023-10-01T00:00:00Z"
   end_time: "2023-10-31T23:59:59Z"
 

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -7,6 +7,7 @@
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.5",
@@ -26,6 +27,7 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.58.1",
         "recharts": "^2.15.3",
+        "swr": "^2.3.3",
         "tailwind-merge": "^3.3.1",
         "tw-animate-css": "^1.3.4",
         "zod": "^3.25.67",
@@ -196,6 +198,8 @@
 
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ=="],
 
+    "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-menu": "2.1.15", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ=="],
+
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA=="],
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
@@ -203,6 +207,8 @@
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
     "@radix-ui/react-label": ["@radix-ui/react-label@2.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ=="],
+
+    "@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.10", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tVlmA3Vb9n8SZSd+YSbuFR66l87Wiy4du+YE+0hzKQEANA+7cWKH1WgqcEX4pXqxUFQKrWQGHdvEfw00TjFiew=="],
 
     "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ=="],
 
@@ -513,6 +519,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
@@ -977,6 +985,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "swr": ["swr@2.3.3", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A=="],
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.5",
@@ -32,6 +33,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.58.1",
     "recharts": "^2.15.3",
+    "swr": "^2.3.3",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.4",
     "zod": "^3.25.67"

--- a/frontend/src/app/api/login/route.ts
+++ b/frontend/src/app/api/login/route.ts
@@ -17,11 +17,15 @@ export async function POST(req: NextRequest) {
   params.append('password', password as string);
 
   try {
-    const response = await axios.post(BACKEND_URL + '/api/v1/auth/login', params, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
-    });
+    const response = await axios.post(
+      BACKEND_URL + '/api/v1/auth/login',
+      params,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
+    );
 
     if (response.status !== 200) {
       return NextResponse.json(
@@ -29,7 +33,10 @@ export async function POST(req: NextRequest) {
         { status: response.status },
       );
     }
-    if (!response.headers['set-cookie'] || response.headers['set-cookie'].length === 0) {
+    if (
+      !response.headers['set-cookie'] ||
+      response.headers['set-cookie'].length === 0
+    ) {
       return NextResponse.json(
         { error: 'No session cookie received' },
         { status: 500 },
@@ -37,7 +44,10 @@ export async function POST(req: NextRequest) {
     }
 
     const nextResponse = NextResponse.json({ result: 'Login succefully' });
-    nextResponse.headers.set('Set-Cookie', response.headers['set-cookie'].join('; '));
+    nextResponse.headers.set(
+      'Set-Cookie',
+      response.headers['set-cookie'].join('; '),
+    );
     return nextResponse;
   } catch (error) {
     console.error('Error calling external API:', error);

--- a/frontend/src/app/logs/column.tsx
+++ b/frontend/src/app/logs/column.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Badge } from "@/components/ui/badge"
+import { MoreHorizontal, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react"
+
+// This type is used to define the shape of our data.
+// You can use a Zod schema here if you want.
+export type Flag = {
+  flag_code: string;
+  service_name: string;
+  status: 'ACCEPTED' | 'DENIED' | 'RESUBMIT' | 'ERROR';
+  exploit_name: string;
+  msg: string;
+  submit_time: number;
+  response_time: number;
+  port_service: number;
+  team_id: number;
+};
+
+
+const getStatusBadge = (status: string) => {
+  switch (status) {
+    case 'ACCEPTED':
+      return (
+        <Badge className="border-green-500/20 bg-green-500/10 text-green-500">
+          Accepted
+        </Badge>
+      );
+    case 'RESUBMIT':
+      return (
+        <Badge className="border-yellow-500/20 bg-yellow-500/10 text-yellow-500">
+          Resubmit
+        </Badge>
+      );
+    case 'DENIED':
+      return (
+        <Badge className="border-red-500/20 bg-red-500/10 text-red-500">
+          Denied
+        </Badge>
+      );
+    case 'ERROR':
+      return (
+        <Badge className="border-gray-500/20 bg-gray-500/10 text-gray-500">
+          Error
+        </Badge>
+      );
+    default:
+      return <Badge variant="outline">{status}</Badge>;
+  }
+};
+
+export const columns: ColumnDef<Flag>[] = [
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      return getStatusBadge(row.getValue("status"));
+    },
+    size: 120,
+  },
+  {
+    accessorKey: "flag_code",
+    header: "Flag Code",
+    cell: ({ row }) => {
+      const flagCode = row.getValue("flag_code") as string;
+      return (
+        <div className="font-mono text-xs sm:text-sm max-w-[120px] sm:max-w-[200px] truncate" title={flagCode}>
+          {flagCode}
+        </div>
+      );
+    },
+    size: 200,
+  },
+  {
+    accessorKey: "service_name",
+    header: "Service",
+    cell: ({ row }) => {
+      const serviceName = row.getValue("service_name") as string;
+      return (
+        <div className="max-w-[100px] sm:max-w-[150px] truncate" title={serviceName}>
+          {serviceName}
+        </div>
+      );
+    },
+    size: 150,
+  },
+  {
+    accessorKey: "port_service",
+    header: "Port",
+    cell: ({ row }) => {
+      return (
+        <Badge variant="secondary" className="font-mono text-xs">
+          {row.getValue("port_service")}
+        </Badge>
+      );
+    },
+    size: 80,
+  },
+  {
+    accessorKey: "exploit_name",
+    header: "Exploit",
+    cell: ({ row }) => {
+      const exploitName = row.getValue("exploit_name") as string;
+      return (
+        <div className="max-w-[100px] sm:max-w-[150px] truncate" title={exploitName}>
+          {exploitName}
+        </div>
+      );
+    },
+    size: 150,
+  },
+  {
+    accessorKey: "msg",
+    header: "Message",
+    cell: ({ row }) => {
+      const message = row.getValue("msg") as string;
+      return (
+        <div className="max-w-[150px] sm:max-w-[300px] truncate text-xs sm:text-sm" title={message}>
+          {message}
+        </div>
+      );
+    },
+    size: 300,
+  },
+  {
+    accessorKey: "team_id",
+    header: "Team",
+    cell: ({ row }) => {
+      return (
+        <Badge variant="outline" className="font-mono">
+          {row.getValue("team_id")}
+        </Badge>
+      );
+    },
+    size: 80,
+  },
+  {
+    accessorKey: "submit_time",
+    header: "Submitted",
+    cell: ({ row }) => {
+      const submitTime = row.getValue("submit_time") as number;
+      const date = new Date(submitTime * 1000);
+      return (
+        <div className="text-xs sm:text-sm whitespace-nowrap">
+          <div>{date.toLocaleDateString()}</div>
+          <div className="text-muted-foreground">{date.toLocaleTimeString()}</div>
+        </div>
+      );
+    },
+    size: 120,
+  },
+  {
+    accessorKey: "response_time",
+    header: "Duration",
+    cell: ({ row }) => {
+      const responseTime = row.getValue("response_time") as number;
+      const submitTime = row.getValue("submit_time") as number;
+      const duration = responseTime - submitTime;
+      if (isNaN(duration) || duration < 0) {
+        return <span className="text-muted-foreground text-xs">N/A</span>;
+      }
+      return (
+        <Badge variant="outline" className="font-mono text-xs">
+          {duration}s
+        </Badge>
+      );
+    },
+    size: 80,
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const flag = row.original
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild >
+            <Button variant="ghost" className="h-8 w-8 p-0" >
+              <span className="sr-only" > Open menu </span>
+              < MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          < DropdownMenuContent align="end" >
+            <DropdownMenuLabel>Actions </DropdownMenuLabel>
+            < DropdownMenuItem onClick={() => navigator.clipboard.writeText(flag.flag_code)}>
+              Copy flag code
+            </DropdownMenuItem>
+            < DropdownMenuSeparator />
+            <DropdownMenuItem>View details </DropdownMenuItem>
+            < DropdownMenuItem > View exploit </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )
+    },
+  },
+]

--- a/frontend/src/app/logs/data-table.tsx
+++ b/frontend/src/app/logs/data-table.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  totalCount: number
+  pageIndex: number
+  pageSize: number
+  onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  totalCount,
+  pageIndex,
+  pageSize,
+  onPaginationChange,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    pageCount: Math.ceil(totalCount / pageSize),
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+    },
+    onPaginationChange: (updater) => {
+      if (typeof updater === 'function') {
+        const newState = updater({ pageIndex, pageSize });
+        onPaginationChange(newState);
+      } else {
+        onPaginationChange(updater);
+      }
+    },
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border overflow-hidden">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder ? null :
+                          flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )
+                        }
+                      </TableHead>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows?.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-32 text-center">
+                    <div className="flex flex-col items-center space-y-2">
+                      <div className="text-muted-foreground">
+                        {totalCount === 0 ? (
+                          <>
+                            <p className="text-lg font-medium">No flags found</p>
+                            <p className="text-sm">There are no flags in the system yet.</p>
+                          </>
+                        ) : (
+                          <>
+                            <p className="text-lg font-medium">No matching results</p>
+                            <p className="text-sm">Try adjusting your search criteria or filters.</p>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between mx-4">
+          {/* Page Size Selector */}
+          <div className="flex items-center space-x-2">
+            <p className="text-xs sm:text-sm font-medium whitespace-nowrap">Rows per page</p>
+            <Select
+              value={`${pageSize}`}
+              onValueChange={(value) => {
+                onPaginationChange({
+                  pageIndex: 0,
+                  pageSize: Number(value),
+                });
+              }}
+            >
+              <SelectTrigger className="h-8 w-[60px] sm:w-[70px]">
+                <SelectValue placeholder={pageSize} />
+              </SelectTrigger>
+              <SelectContent side="top">
+                {[20, 50, 100, 200].map((size) => (
+                  <SelectItem key={size} value={`${size}`}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Page Info */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+            <div className="text-center sm:text-left">
+              <p className="text-xs sm:text-sm font-medium">
+                Page {pageIndex + 1} of {Math.ceil(totalCount / pageSize)}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Showing {pageIndex * pageSize + 1} to {Math.min((pageIndex + 1) * pageSize, totalCount)} of {totalCount}
+              </p>
+            </div>
+
+            {/* Navigation Controls */}
+            <div className="flex items-center justify-center space-x-1 sm:space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden h-8 w-8 p-0 sm:flex"
+                onClick={() => onPaginationChange({ pageIndex: 0, pageSize })}
+                disabled={pageIndex === 0}
+              >
+                <span className="sr-only">Go to first page</span>
+                {"<<"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to previous page</span>
+                {"<"}
+              </Button>
+
+              {/* Page Numbers for larger screens */}
+              <div className="hidden md:flex items-center space-x-1">
+                {Array.from({ length: Math.min(5, Math.ceil(totalCount / pageSize)) }, (_, i) => {
+                  const pageNum = Math.max(0, Math.min(
+                    Math.ceil(totalCount / pageSize) - 5,
+                    pageIndex - 2
+                  )) + i;
+
+                  if (pageNum >= Math.ceil(totalCount / pageSize)) return null;
+
+                  return (
+                    <Button
+                      key={pageNum}
+                      variant={pageNum === pageIndex ? "default" : "outline"}
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => onPaginationChange({ pageIndex: pageNum, pageSize })}
+                    >
+                      {pageNum + 1}
+                    </Button>
+                  );
+                })}
+              </div>
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to next page</span>
+                {">"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden h-8 w-8 p-0 sm:flex"
+                onClick={() => onPaginationChange({
+                  pageIndex: Math.ceil(totalCount / pageSize) - 1,
+                  pageSize
+                })}
+                disabled={pageIndex >= Math.ceil(totalCount / pageSize) - 1}
+              >
+                <span className="sr-only">Go to last page</span>
+                {">>"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/logs/filter-panel.tsx
+++ b/frontend/src/app/logs/filter-panel.tsx
@@ -1,0 +1,357 @@
+"use client"
+
+import { useState } from 'react'
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+// Removed Collapsible import for compatibility
+import { Badge } from "@/components/ui/badge"
+import {
+  Search,
+  Filter,
+  X,
+  ChevronDown,
+  ChevronUp,
+  SortAsc,
+  SortDesc,
+  ArrowUpDown
+} from "lucide-react"
+import { SortingState, ColumnFiltersState } from '@tanstack/react-table'
+
+interface FilterPanelProps {
+  // Search
+  globalFilter: string
+  onGlobalFilterChange: (value: string) => void
+  searchField: string
+  onSearchFieldChange: (field: string) => void
+
+  // Sorting
+  sorting: SortingState
+  onSortingChange: (sorting: SortingState) => void
+  sortField: string
+  onSortFieldChange: (field: string) => void
+  sortDirection: 'asc' | 'desc'
+  onSortDirectionChange: (direction: 'asc' | 'desc') => void
+
+  // Filters
+  columnFilters: ColumnFiltersState
+  onColumnFiltersChange: (filters: ColumnFiltersState) => void
+  statusFilter: string
+  onStatusFilterChange: (status: string) => void
+  serviceFilter: string
+  onServiceFilterChange: (service: string) => void
+  teamFilter: string
+  onTeamFilterChange: (team: string) => void
+
+  // Stats
+  totalCount: number
+  filteredCount: number
+
+  // Actions
+  onClearAll: () => void
+}
+
+const searchableFields = [
+  { value: 'all', label: 'All Fields' },
+  { value: 'flag_code', label: 'Flag Code' },
+  { value: 'service_name', label: 'Service Name' },
+  { value: 'port_service', label: 'Service Port' },
+  { value: 'exploit_name', label: 'Exploit Name' },
+  { value: 'msg', label: 'Message' },
+  { value: 'username', label: 'Username' }
+]
+
+const sortableFields = [
+  { value: 'submit_time', label: 'Submit Time' },
+  { value: 'response_time', label: 'Response Time' },
+  { value: 'status', label: 'Status' },
+  { value: 'flag_code', label: 'Flag Code' },
+  { value: 'service_name', label: 'Service Name' },
+  { value: 'team_id', label: 'Team ID' },
+  { value: 'port_service', label: 'Port' },
+]
+
+const statusOptions = [
+  { value: 'all', label: 'All Statuses' },
+  { value: 'ACCEPTED', label: 'Accepted' },
+  { value: 'DENIED', label: 'Denied' },
+  { value: 'RESUBMIT', label: 'Resubmit' },
+  { value: 'ERROR', label: 'Error' },
+]
+
+export function FilterPanel({
+  globalFilter,
+  onGlobalFilterChange,
+  searchField,
+  onSearchFieldChange,
+  sorting,
+  onSortingChange,
+  sortField,
+  onSortFieldChange,
+  sortDirection,
+  onSortDirectionChange,
+  columnFilters,
+  onColumnFiltersChange,
+  statusFilter,
+  onStatusFilterChange,
+  serviceFilter,
+  onServiceFilterChange,
+  teamFilter,
+  onTeamFilterChange,
+  totalCount,
+  filteredCount,
+  onClearAll,
+}: FilterPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const hasActiveFilters = globalFilter ||
+    statusFilter !== 'all' ||
+    serviceFilter ||
+    teamFilter ||
+    columnFilters.length > 0
+
+  const activeFiltersCount = [
+    globalFilter,
+    statusFilter !== 'all' ? statusFilter : null,
+    serviceFilter,
+    teamFilter,
+    ...columnFilters.map(f => f.value)
+  ].filter(Boolean).length
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Filter className="h-5 w-5" />
+              Search & Filters
+              {activeFiltersCount > 0 && (
+                <Badge variant="secondary" className="ml-2">
+                  {activeFiltersCount}
+                </Badge>
+              )}
+            </CardTitle>
+            <CardDescription className="text-sm">
+              {filteredCount} of {totalCount} flags shown
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            {hasActiveFilters && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onClearAll}
+                className="h-8"
+              >
+                <X className="h-4 w-4 mr-1" />
+                Clear All
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={() => setIsExpanded(!isExpanded)}
+            >
+              {isExpanded ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Quick Search Row - Always Visible */}
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
+          {/* Search Field Selector */}
+          <div className="md:col-span-3 flex gap-2">
+            <Select value={searchField} onValueChange={onSearchFieldChange}>
+              <SelectTrigger className="h-10">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {searchableFields.map((field) => (
+                  <SelectItem key={field.value} value={field.value}>
+                    {field.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Quick Status Filter */}
+            <Select value={statusFilter} onValueChange={onStatusFilterChange}>
+              <SelectTrigger className="h-10">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+
+          {/* Search Input */}
+          <div className="md:col-span-6 relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder={`Search ${searchableFields.find(f => f.value === searchField)?.label.toLowerCase() || 'all fields'}...`}
+              value={globalFilter}
+              onChange={(e) => onGlobalFilterChange(e.target.value)}
+              className="pl-10 h-10"
+            />
+            {globalFilter && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onGlobalFilterChange('')}
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 h-6 w-6 p-0"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
+          </div>
+
+
+        </div>
+
+        {/* Expanded Filters */}
+        {isExpanded && (
+          <div className="space-y-4 border-t pt-4">
+            {/* Sort Controls */}
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium flex items-center gap-2">
+                <ArrowUpDown className="h-4 w-4" />
+                Sort By
+              </h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <Select value={sortField} onValueChange={onSortFieldChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select field to sort by" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sortableFields.map((field) => (
+                      <SelectItem key={field.value} value={field.value}>
+                        {field.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={sortDirection} onValueChange={onSortDirectionChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="asc">
+                      <div className="flex items-center gap-2">
+                        <SortAsc className="h-4 w-4" />
+                        Ascending
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="desc">
+                      <div className="flex items-center gap-2">
+                        <SortDesc className="h-4 w-4" />
+                        Descending
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Active Filters Display */}
+            {(hasActiveFilters) && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium">Active Filters</h4>
+                <div className="flex flex-wrap gap-2">
+                  {globalFilter && (
+                    <Badge variant="secondary" className="text-xs">
+                      Search: "{globalFilter}"
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onGlobalFilterChange('')}
+                        className="ml-1 h-auto p-0 text-xs hover:bg-transparent"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </Badge>
+                  )}
+
+                  {statusFilter !== 'all' && (
+                    <Badge variant="secondary" className="text-xs">
+                      Status: {statusOptions.find(s => s.value === statusFilter)?.label}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onStatusFilterChange('all')}
+                        className="ml-1 h-auto p-0 text-xs hover:bg-transparent"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </Badge>
+                  )}
+
+                  {serviceFilter && (
+                    <Badge variant="secondary" className="text-xs">
+                      Service: "{serviceFilter}"
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onServiceFilterChange('')}
+                        className="ml-1 h-auto p-0 text-xs hover:bg-transparent"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </Badge>
+                  )}
+
+                  {teamFilter && (
+                    <Badge variant="secondary" className="text-xs">
+                      Team: {teamFilter}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onTeamFilterChange('')}
+                        className="ml-1 h-auto p-0 text-xs hover:bg-transparent"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </Badge>
+                  )}
+
+                  {sorting.length > 0 && (
+                    <Badge variant="outline" className="text-xs">
+                      Sort: {sortableFields.find(f => f.value === sortField)?.label} ({sortDirection})
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/logs/loading.tsx
+++ b/frontend/src/app/logs/loading.tsx
@@ -1,3 +1,12 @@
 export default function Loading() {
-  return null;
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="flex flex-col items-center space-y-4">
+        <div className="relative">
+          <div className="w-12 h-12 border-4 border-gray-200 border-t-blue-600 rounded-full animate-spin"></div>
+        </div>
+        <p className="text-sm text-muted-foreground animate-pulse">Loading...</p>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import {
   Card,
   CardContent,
@@ -9,255 +8,124 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { Search, Filter } from 'lucide-react';
+import { columns, Flag } from './column';
+import { DataTable } from './data-table';
+import { FilterPanel } from './filter-panel';
+import Loading from './loading';
+import { usePaginatedFlags } from '@/hooks/usePaginatedFlags';
 
-// Mock flag log data
-const flagLogs = [
-  {
-    id: 'FL001',
-    code: 'FLAG{web_exploit_alpha_r6}',
-    team: { name: 'Team Alpha', id: 'team1', ip: '10.0.1.100' },
-    status: 'Accepted',
-    executionTime: '2024-01-15 14:32:15',
-    exploitTime: '2024-01-15 14:31:45',
-  },
-  {
-    id: 'FL002',
-    code: 'FLAG{db_injection_beta_r6}',
-    team: { name: 'Team Beta', id: 'team2', ip: '10.0.2.100' },
-    status: 'Pending',
-    executionTime: '2024-01-15 14:31:58',
-    exploitTime: '2024-01-15 14:31:20',
-  },
-  {
-    id: 'FL003',
-    code: 'FLAG{api_overflow_gamma_r6}',
-    team: { name: 'Team Gamma', id: 'team3', ip: '10.0.3.100' },
-    status: 'Denied',
-    executionTime: '2024-01-15 14:31:42',
-    exploitTime: '2024-01-15 14:31:10',
-  },
-  {
-    id: 'FL004',
-    code: 'FLAG{file_traversal_delta_r6}',
-    team: { name: 'Team Delta', id: 'team4', ip: '10.0.4.100' },
-    status: 'Accepted',
-    executionTime: '2024-01-15 14:31:28',
-    exploitTime: '2024-01-15 14:30:55',
-  },
-  {
-    id: 'FL005',
-    code: 'FLAG{crypto_weak_alpha_r5}',
-    team: { name: 'Team Alpha', id: 'team1', ip: '10.0.1.100' },
-    status: 'Accepted',
-    executionTime: '2024-01-15 14:25:33',
-    exploitTime: '2024-01-15 14:25:10',
-  },
-  {
-    id: 'FL006',
-    code: 'FLAG{network_sniff_beta_r5}',
-    team: { name: 'Team Beta', id: 'team2', ip: '10.0.2.100' },
-    status: 'Denied',
-    executionTime: '2024-01-15 14:24:17',
-    exploitTime: '2024-01-15 14:23:45',
-  },
-  {
-    id: 'FL007',
-    code: 'FLAG{buffer_overflow_gamma_r5}',
-    team: { name: 'Team Gamma', id: 'team3', ip: '10.0.3.100' },
-    status: 'Accepted',
-    executionTime: '2024-01-15 14:23:52',
-    exploitTime: '2024-01-15 14:23:20',
-  },
-  {
-    id: 'FL008',
-    code: 'FLAG{sql_injection_delta_r5}',
-    team: { name: 'Team Delta', id: 'team4', ip: '10.0.4.100' },
-    status: 'Pending',
-    executionTime: '2024-01-15 14:23:08',
-    exploitTime: '2024-01-15 14:22:35',
-  },
-];
-
-const getStatusBadge = (status: string) => {
-  switch (status) {
-    case 'Accepted':
-      return (
-        <Badge className="border-green-500/20 bg-green-500/10 text-green-500">
-          Accepted
-        </Badge>
-      );
-    case 'Pending':
-      return (
-        <Badge className="border-yellow-500/20 bg-yellow-500/10 text-yellow-500">
-          Pending
-        </Badge>
-      );
-    case 'Denied':
-      return (
-        <Badge className="border-red-500/20 bg-red-500/10 text-red-500">
-          Denied
-        </Badge>
-      );
-    default:
-      return <Badge variant="outline">{status}</Badge>;
-  }
-};
 
 export default function FlagLogs() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState('All');
-  const [teamFilter, setTeamFilter] = useState('All');
+  const {
+    data: filteredData,
+    totalCount,
+    isLoading,
+    error,
+    pagination,
+    filters,
+    sorting,
+    columnFilters,
 
-  const filteredLogs = flagLogs.filter(log => {
-    const matchesSearch =
-      log.code.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      log.team.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      log.id.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesStatus = statusFilter === 'All' || log.status === statusFilter;
-    const matchesTeam = teamFilter === 'All' || log.team.name === teamFilter;
+    setPagination,
+    setSearchTerm,
+    setSearchField,
+    setStatusFilter,
+    setServiceFilter,
+    setTeamFilter,
+    setSortField,
+    setSortDirection,
+    setSorting,
+    setColumnFilters,
 
-    return matchesSearch && matchesStatus && matchesTeam;
-  });
+    onClearAll,
+  } = usePaginatedFlags();
+
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="flex flex-col items-center space-y-4">
+          <div className="text-red-500 text-lg font-semibold">Error loading flags</div>
+          <p className="text-sm text-muted-foreground">
+            {error.message || 'Failed to fetch flag data. Please try again.'}
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex items-center justify-between">
+    <div className="container mx-auto p-4 space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-foreground text-3xl font-bold">Flag Logs</h1>
-          <p className="text-muted-foreground">
-            View and manage all submitted flags with detailed information
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Flag Logs</h1>
+          <p className="text-muted-foreground text-sm sm:text-base">
+            Advanced server-side filtering, searching, sorting and pagination
           </p>
         </div>
-        <Badge variant="outline" className="text-sm">
-          {filteredLogs.length} flags
-        </Badge>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="outline" className="text-xs sm:text-sm">
+            {filteredData.length} results
+          </Badge>
+          <Badge variant="secondary" className="text-xs sm:text-sm">
+            Page {pagination.pageIndex + 1} of {Math.ceil(totalCount / pagination.pageSize)}
+          </Badge>
+          <Badge variant="default" className="text-xs sm:text-sm">
+            {totalCount} filtered
+          </Badge>
+        </div>
       </div>
 
-      {/* Filters */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Filter className="h-5 w-5" />
-            Filters & Search
-          </CardTitle>
-          <CardDescription>
-            Filter flags by status, team, or search by flag code
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Search</label>
-              <div className="relative">
-                <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform" />
-                <Input
-                  placeholder="Search flags, teams, or IDs..."
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Status</label>
-              <Select value={statusFilter} onValueChange={setStatusFilter}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="All">All Statuses</SelectItem>
-                  <SelectItem value="Accepted">Accepted</SelectItem>
-                  <SelectItem value="Pending">Pending</SelectItem>
-                  <SelectItem value="Denied">Denied</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Team</label>
-              <Select value={teamFilter} onValueChange={setTeamFilter}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="All">All Teams</SelectItem>
-                  <SelectItem value="Team Alpha">Team Alpha</SelectItem>
-                  <SelectItem value="Team Beta">Team Beta</SelectItem>
-                  <SelectItem value="Team Gamma">Team Gamma</SelectItem>
-                  <SelectItem value="Team Delta">Team Delta</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Filter Panel */}
+      <FilterPanel
+        globalFilter={filters.searchTerm}
+        onGlobalFilterChange={setSearchTerm}
+        searchField={filters.searchField}
+        onSearchFieldChange={setSearchField}
+        sorting={sorting}
+        onSortingChange={setSorting}
+        sortField={filters.sortField}
+        onSortFieldChange={setSortField}
+        sortDirection={filters.sortDirection}
+        onSortDirectionChange={setSortDirection}
+        columnFilters={columnFilters}
+        onColumnFiltersChange={setColumnFilters}
+        statusFilter={filters.statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        serviceFilter={filters.serviceFilter}
+        onServiceFilterChange={setServiceFilter}
+        teamFilter={filters.teamFilter}
+        onTeamFilterChange={setTeamFilter}
+        totalCount={totalCount}
+        filteredCount={filteredData.length}
+        onClearAll={onClearAll}
+      />
 
-      {/* Flag Logs Table */}
+      {/* Data Table */}
       <Card>
-        <CardHeader>
-          <CardTitle>Flag Submissions</CardTitle>
-          <CardDescription>
-            Complete log of all flag submissions and their status
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg sm:text-xl">Flag Submissions</CardTitle>
+          <CardDescription className="text-sm">
+
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <div className="rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Flag ID</TableHead>
-                  <TableHead>Flag Code</TableHead>
-                  <TableHead>Team</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Execution Time</TableHead>
-                  <TableHead>Exploit Time</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredLogs.map(log => (
-                  <TableRow key={log.id}>
-                    <TableCell className="font-mono text-sm">
-                      {log.id}
-                    </TableCell>
-                    <TableCell className="max-w-xs truncate font-mono text-sm">
-                      {log.code}
-                    </TableCell>
-                    <TableCell>
-                      <div className="space-y-1">
-                        <div className="font-medium">{log.team.name}</div>
-                        <div className="text-muted-foreground text-xs">
-                          {log.team.id} • {log.team.ip}
-                        </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>{getStatusBadge(log.status)}</TableCell>
-                    <TableCell className="font-mono text-sm">
-                      {log.executionTime}
-                    </TableCell>
-                    <TableCell className="font-mono text-sm">
-                      {log.exploitTime}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+        <CardContent className="p-0 sm:p-6">
+          <DataTable
+            key={`${JSON.stringify(filters)}-${pagination.pageIndex}-${pagination.pageSize}`}
+            columns={columns}
+            data={filteredData}
+            totalCount={totalCount}
+            pageIndex={pagination.pageIndex}
+            pageSize={pagination.pageSize}
+            onPaginationChange={setPagination}
+          />
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/src/hooks/usePaginatedFlags.ts
+++ b/frontend/src/hooks/usePaginatedFlags.ts
@@ -1,0 +1,222 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import useSWR from 'swr';
+import { fetcher } from '@/lib/fetchers';
+import { BACKEND_URL } from '@/lib/constants';
+import { Flag } from '@/app/logs/column';
+import { SortingState, ColumnFiltersState } from '@tanstack/react-table';
+
+interface PaginationState {
+  pageIndex: number;
+  pageSize: number;
+}
+
+interface FilterState {
+  searchTerm: string;
+  searchField: string;
+  statusFilter: string;
+  serviceFilter: string;
+  teamFilter: string;
+  sortField: string;
+  sortDirection: 'asc' | 'desc';
+}
+
+interface ApiResponse {
+  flags: Flag[];
+  n_flags: number;
+}
+
+interface UsePaginatedFlagsReturn {
+  data: Flag[];
+  totalCount: number;
+  isLoading: boolean;
+  error: any;
+  pagination: PaginationState;
+  filters: FilterState;
+  sorting: SortingState;
+  columnFilters: ColumnFiltersState;
+  setPagination: (pagination: PaginationState) => void;
+  setFilters: (filters: Partial<FilterState>) => void;
+  setSearchTerm: (term: string) => void;
+  setSearchField: (field: string) => void;
+  setStatusFilter: (status: string) => void;
+  setServiceFilter: (service: string) => void;
+  setTeamFilter: (team: string) => void;
+  setSortField: (field: string) => void;
+  setSortDirection: (direction: 'asc' | 'desc') => void;
+  setSorting: (sorting: SortingState) => void;
+  setColumnFilters: (filters: ColumnFiltersState) => void;
+  onClearAll: () => void;
+}
+
+export function usePaginatedFlags(): UsePaginatedFlagsReturn {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  });
+
+  const [filters, setFiltersState] = useState<FilterState>({
+    searchTerm: '',
+    searchField: 'all',
+    statusFilter: 'all',
+    serviceFilter: '',
+    teamFilter: '',
+    sortField: 'submit_time',
+    sortDirection: 'desc',
+  });
+
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+  const debounceTimer = useRef<NodeJS.Timeout>();
+
+  // TanStack Table state
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  // Proper debounce for search term
+  const debounceSearch = useCallback((searchTerm: string) => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm);
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    debounceSearch(filters.searchTerm);
+    return () => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+      }
+    };
+  }, [filters.searchTerm, debounceSearch]);
+
+  // Build URL with new clean endpoint parameters
+  const buildUrl = () => {
+    const baseUrl = `${BACKEND_URL}/api/v1/flags/${pagination.pageSize}`;
+    const params = new URLSearchParams();
+
+    params.set('offset', (pagination.pageIndex * pagination.pageSize).toString());
+
+    // Status filter
+    if (filters.statusFilter !== 'all') {
+      params.set('status', filters.statusFilter);
+    }
+
+    // Service filter
+    if (filters.serviceFilter) {
+      params.set('service', filters.serviceFilter);
+    }
+
+    // Team filter
+    if (filters.teamFilter) {
+      params.set('team', filters.teamFilter);
+    }
+
+    // Search parameters
+    if (debouncedSearchTerm) {
+      params.set('search', debouncedSearchTerm);
+      params.set('search_field', filters.searchField);
+    }
+
+    // Sort parameters
+    if (filters.sortField) {
+      params.set('sort_field', filters.sortField);
+      params.set('sort_dir', filters.sortDirection.toUpperCase());
+    }
+    const finalUrl = `${baseUrl}?${params.toString()}`;
+    return finalUrl;
+  };
+
+  const paginatedUrl = buildUrl();
+  const { data: rawData, error, isLoading } = useSWR<ApiResponse>(paginatedUrl, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: true,
+    dedupingInterval: 0,
+    keepPreviousData: true
+  });
+
+  const filteredData = useMemo(() => {
+    if (!rawData?.flags || !Array.isArray(rawData.flags)) {
+      return [];
+    }
+    return rawData.flags;
+  }, [rawData?.flags]);
+
+  const setFilters = (newFilters: Partial<FilterState>) => {
+    setFiltersState(prev => ({ ...prev, ...newFilters }));
+    // Reset to first page when filters change
+    setPagination(prev => ({ ...prev, pageIndex: 0 }));
+  };
+
+  const setSearchTerm = (searchTerm: string) => {
+    setFilters({ searchTerm });
+  };
+
+  const setSearchField = (searchField: string) => {
+    setFilters({ searchField });
+  };
+
+  const setStatusFilter = (statusFilter: string) => {
+    setFilters({ statusFilter });
+  };
+
+  const setServiceFilter = (serviceFilter: string) => {
+    setFilters({ serviceFilter });
+  };
+
+  const setTeamFilter = (teamFilter: string) => {
+    setFilters({ teamFilter });
+  };
+
+  const setSortField = (sortField: string) => {
+    setFilters({ sortField });
+  };
+
+  const setSortDirection = (sortDirection: 'asc' | 'desc') => {
+    setFilters({ sortDirection });
+  };
+
+  const onClearAll = () => {
+    setFiltersState({
+      searchTerm: '',
+      searchField: 'all',
+      statusFilter: 'all',
+      serviceFilter: '',
+      teamFilter: '',
+      sortField: 'submit_time',
+      sortDirection: 'desc',
+    });
+    setSorting([]);
+    setColumnFilters([]);
+    setPagination(prev => ({ ...prev, pageIndex: 0 }));
+  };
+
+  // Reset to first page when filtering changes
+  useEffect(() => {
+    setPagination(prev => ({ ...prev, pageIndex: 0 }));
+  }, [filters.searchTerm, filters.statusFilter, filters.serviceFilter, filters.teamFilter, filters.sortField, filters.sortDirection, filters.searchField]);
+
+  return {
+    data: filteredData,
+    totalCount: rawData?.n_flags || 0,
+    isLoading: isLoading,
+    error,
+    pagination,
+    filters,
+    sorting,
+    columnFilters,
+    setPagination,
+    setFilters,
+    setSearchTerm,
+    setSearchField,
+    setStatusFilter,
+    setServiceFilter,
+    setTeamFilter,
+    setSortField,
+    setSortDirection,
+    setSorting,
+    setColumnFilters,
+    onClearAll,
+  };
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,8 +1,9 @@
-import axios from "axios";
-import { BACKEND_URL } from "./constants";
+import axios from 'axios';
+import { BACKEND_URL } from './constants';
 
-
-export default async function isAuthenticated(request: Request): Promise<boolean> {
+export default async function isAuthenticated(
+  request: Request,
+): Promise<boolean> {
   const cookie = request.headers.get('cookie');
   if (!cookie) {
     return false;
@@ -15,8 +16,8 @@ export default async function isAuthenticated(request: Request): Promise<boolean
   try {
     const response = await axios.get(`${BACKEND_URL}/api/v1/auth/verify`, {
       headers: {
-        'Cookie': cookie
-      }
+        Cookie: cookie,
+      },
     });
 
     if (response.status !== 200) {

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,1 +1,2 @@
-export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+export const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';

--- a/frontend/src/lib/fetchers.ts
+++ b/frontend/src/lib/fetchers.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export const fetcher = async (url: string) => {
+  try {
+    const response = await axios.get(url, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      withCredentials: true,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching flags:', error);
+    return false;
+  }
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,17 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server'
-import isAuthenticated from '@/lib/auth'
+import { NextRequest, NextResponse } from 'next/server';
+import isAuthenticated from '@/lib/auth';
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl
-  const isAuth = await isAuthenticated(request)
+  const { pathname } = request.nextUrl;
+  const isAuth = await isAuthenticated(request);
   if (pathname != '/login' && !isAuth) {
-    console.log('User is not authenticated, redirecting to /login')
-    return NextResponse.redirect(new URL('/login', request.url))
+    console.log('User is not authenticated, redirecting to /login');
+    return NextResponse.redirect(new URL('/login', request.url));
   }
 
-  const response = NextResponse.next()
+  const response = NextResponse.next();
 
-  return response
+  return response;
 }
 
 export const config = {
@@ -24,4 +24,4 @@ export const config = {
      */
     '/((?!_next/static|api|_next/image|images|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
-}
+};

--- a/internal/server/core/config.go
+++ b/internal/server/core/config.go
@@ -40,7 +40,10 @@ func LoadConfig(path string) error {
 
 	go StartFlagProcessingLoop(ctx)
 
-	go ValidateFlagTTL(ctx, config.SharedConfig.ConfigServer.FlagTTL, config.SharedConfig.ConfigServer.TickTime)
+	if config.SharedConfig.ConfigServer.FlagTTL != 0 {
+		logger.Log.Warn().Msgf("Flag TTL is set to %d seconds, starting validation loop", config.SharedConfig.ConfigServer.FlagTTL)
+		go ValidateFlagTTL(ctx, config.SharedConfig.ConfigServer.FlagTTL, config.SharedConfig.ConfigServer.TickTime)
+	}
 
 	return nil
 }

--- a/internal/server/server/routes.go
+++ b/internal/server/server/routes.go
@@ -21,7 +21,7 @@ func RegisterRoutes(app *fiber.App) {
 	// Enable CORS with dynamic origins from environment variable.
 	// Useful for allowing access from web dashboards or dev clients.
 	app.Use(cors.New(cors.Config{
-		AllowOrigins:     config.GetEnv("ALLOW_ORIGINS", "http://localhost:8080"),
+		AllowOrigins:     config.GetEnv("ALLOW_ORIGINS", "http://localhost:8080,http://localhost:3000"),
 		AllowMethods:     "GET,POST,PUT,DELETE,OPTIONS,PATCH",
 		AllowHeaders:     "Accept,Authorization,Content-Type",
 		AllowCredentials: true,

--- a/internal/server/sqlite/query.go
+++ b/internal/server/sqlite/query.go
@@ -1,0 +1,151 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// NewQueryBuilder creates a new query builder
+func NewQueryBuilder(baseQuery string) *QueryBuilder {
+	return &QueryBuilder{
+		query:      baseQuery,
+		params:     make([]any, 0),
+		conditions: make([]string, 0),
+		hasWhere:   false,
+	}
+}
+
+// AddCondition adds a WHERE condition with parameter binding
+func (qb *QueryBuilder) AddCondition(condition string, params ...any) *QueryBuilder {
+	qb.conditions = append(qb.conditions, condition)
+	qb.params = append(qb.params, params...)
+	return qb
+}
+
+// AddSort adds ORDER BY clause with validation
+func (qb *QueryBuilder) AddSort(field, direction string) *QueryBuilder {
+	validFields := map[string]bool{
+		"submit_time":   true,
+		"response_time": true,
+		"status":        true,
+		"flag_code":     true,
+		"service_name":  true,
+		"team_id":       true,
+		"port_service":  true,
+	}
+
+	validDirections := map[string]bool{
+		"ASC":  true,
+		"DESC": true,
+	}
+
+	if validFields[field] && validDirections[direction] {
+		qb.query += fmt.Sprintf(" ORDER BY %s %s", field, direction)
+	} else {
+		qb.query += " ORDER BY submit_time DESC"
+	}
+	return qb
+}
+
+// AddPagination adds LIMIT and OFFSET
+func (qb *QueryBuilder) AddPagination(limit, offset uint) *QueryBuilder {
+	if limit > 0 {
+		qb.query += fmt.Sprintf(" LIMIT %d", limit)
+	}
+	if offset > 0 {
+		qb.query += fmt.Sprintf(" OFFSET %d", offset)
+	}
+	return qb
+}
+
+// Build finalizes the query and returns query string with parameters
+func (qb *QueryBuilder) Build() (string, []any) {
+	return qb.query, qb.params
+}
+
+func buildFilterConditions(opts FilterOptions) (*QueryBuilder, []any) {
+	qb := NewQueryBuilder("")
+
+	// Add status filter
+	if opts.Status != "" && opts.Status != "all" {
+		qb.AddCondition("status = ?", opts.Status)
+	}
+
+	// Add service filter
+	if opts.ServiceName != "" {
+		qb.AddCondition("service_name LIKE ?", "%"+opts.ServiceName+"%")
+	}
+
+	// Add team filter
+	if opts.TeamID != "" {
+		qb.AddCondition("team_id = ?", opts.TeamID)
+	}
+
+	// Add search
+	if opts.Search != "" {
+		switch opts.SearchField {
+		case "flag_code":
+			qb.AddCondition("flag_code LIKE ?", "%"+opts.Search+"%")
+		case "service_name":
+			qb.AddCondition("service_name LIKE ?", "%"+opts.Search+"%")
+		case "exploit_name":
+			qb.AddCondition("exploit_name LIKE ?", "%"+opts.Search+"%")
+		case "msg":
+			qb.AddCondition("msg LIKE ?", "%"+opts.Search+"%")
+		case "all":
+			qb.AddCondition("(flag_code LIKE ? OR service_name LIKE ? OR exploit_name LIKE ? OR msg LIKE ? OR CAST(team_id AS TEXT) LIKE ?)",
+				"%"+opts.Search+"%", "%"+opts.Search+"%", "%"+opts.Search+"%", "%"+opts.Search+"%", "%"+opts.Search+"%")
+		default:
+			qb.AddCondition("flag_code LIKE ?", "%"+opts.Search+"%")
+		}
+	}
+
+	_, params := qb.Build()
+	return qb, params
+}
+
+func CountFilteredFlags(opts FilterOptions) (int, error) {
+	qb := NewQueryBuilder("SELECT COUNT(*) FROM flags")
+	filterQb, params := buildFilterConditions(opts)
+
+	// Apply WHERE conditions for count query
+	if len(filterQb.conditions) > 0 {
+		qb.query += " WHERE " + filterQb.conditions[0]
+		for i := 1; i < len(filterQb.conditions); i++ {
+			qb.query += " AND " + filterQb.conditions[i]
+		}
+	}
+	qb.params = append(qb.params, params...)
+
+	query, finalParams := qb.Build()
+
+	conn := DBPool.Get(context.Background())
+	if conn == nil {
+		return 0, errors.New("no available SQLite connection")
+	}
+	defer DBPool.Put(conn)
+
+	stmt, err := conn.Prepare(query)
+	if err != nil {
+		return 0, fmt.Errorf("prepare CountFilteredFlags: %w", err)
+	}
+	defer stmt.Finalize()
+
+	// Bind parameters
+	stmt, err = BindParams(stmt, finalParams...)
+	if err != nil {
+		return 0, fmt.Errorf("bind params: %w", err)
+	}
+
+	hasRow, err := stmt.Step()
+	if err != nil {
+		return 0, fmt.Errorf("step: %w", err)
+	}
+	if !hasRow {
+		return 0, errors.New("no row returned from COUNT query")
+	}
+
+	count := stmt.ColumnInt(0)
+	return count, nil
+}

--- a/internal/server/sqlite/types.go
+++ b/internal/server/sqlite/types.go
@@ -1,0 +1,22 @@
+package sqlite
+
+// FilterOptions represents query filter options
+type FilterOptions struct {
+	Status      string
+	ServiceName string
+	TeamID      string
+	Search      string
+	SearchField string
+	SortField   string
+	SortDir     string
+	Limit       uint
+	Offset      uint
+}
+
+// QueryBuilder for building safe SQL queries with parameter binding
+type QueryBuilder struct {
+	query      string
+	params     []any
+	conditions []string
+	hasWhere   bool
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
     "tailwindcss-animate": "^1.0.7"
   }
 }


### PR DESCRIPTION
- Implement server-side filtering, searching, sorting, and pagination
for flag logs - Add new frontend components: column definitions, data
table, filter panel, and loading state - Integrate SWR and new
dependencies (@radix-ui/react-dropdown-menu, swr) - Add
usePaginatedFlags hook for paginated flag fetching and filter state -
Update backend API to support filtering, searching, and sorting via
query params - Add SQLite query builder for flexible flag queries and
filtered count - Make flag TTL validation optional if set to 0 in config
- Allow CORS from both localhost:8080 and localhost:3000 - Update config
and Air config for new flag TTL and CLI usage