### PR TITLE
Add Go test coverage and Sonar integration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,4 @@
-name: Sonar Qube Scan
+name: Sonar Qube Scan + tests
 
 on:
   push:
@@ -10,13 +10,30 @@ on:
       - dev
       - main
 
-
 jobs:
   sonar:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: SonarQube Scan Cookiefarm
+        with:
+          fetch-depth: 0  # fix shallow clone warning
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: cookiefarm/server/go.sum
+
+      - name: Install gocover-cobertura
+        run: go install github.com/boumenot/gocover-cobertura@latest
+
+      - name: Run tests & generate coverage
+        working-directory: cookiefarm/server
+        run: |
+          mkdir -p ./coverage
+          go test -coverprofile=./coverage/coverage.out -v ./...
+          gocover-cobertura < ./coverage/coverage.out > ./coverage/coverage.xml
+
+      - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -34,13 +34,15 @@ jobs:
           gocover-cobertura < ./coverage/coverage.out > ./coverage/coverage.xml
 
       - name: SonarQube Scan CookieFarm
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: SonarQube Quality Gate Check
-        uses: SonarSource/sonarqube-quality-gate-action@v1
+        uses: SonarSource/sonarqube-quality-gate-action@master
+        with:
+          pollingTimeoutSec: 600
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -38,3 +38,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      - name: SonarQube Quality Gate Check
+        uses: SonarSource/sonarqube-quality-gate-action@v1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -24,6 +24,7 @@ Need to install:
 - goreleaser (For building and releasing Go binaries)
 - [sqlc](https://docs.sqlc.dev/en/stable/overview/install.html) (For generating Go code from SQL queries) 
 - [gotestsum](https://github.com/gotestyourself/gotestsum) (For running Go tests better)
+- [gocover](go install github.com/boumenot/gocover-cobertura@latest) // For generating code coverage reports in Cobertura format for SonarQube
 ## Client
 
 - Python3.14

--- a/justfile
+++ b/justfile
@@ -181,8 +181,10 @@ server-test:
     @mkdir -p ./coverage
     @gotestsum \
     --post-run-command "notify-send 'Test finished successfully' -a gotestsum -u normal" --format testname \
-    work -coverprofile=./coverage/coverage.out -v \
-    && go tool cover -html=./coverage/coverage.out -o ./coverage/coverage.html && xdg-open ./coverage/coverage.html
+    -- work -coverprofile=./coverage/coverage.out -v ./... \
+    && go tool cover -html=./coverage/coverage.out -o ./coverage/coverage.html \
+    && gocover-cobertura < ./coverage/coverage.out > ./coverage/coverage.xml \
+    && xdg-open ./coverage/coverage.html
 
 # Start all the components for run mock tests mode for testing
 [group('test')]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,9 +14,9 @@ sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.xml
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity
-sonar.issue.ignore.multicriteria=e1
+# sonar.issue.ignore.multicriteria=e1
 # sonar.issue.ignore.multicriteria.e1.ruleKey=*
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
+# sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 
 # Vulnerability severity configuration
 # Low impact vulnerabilities do not fail the quality gate

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,13 +8,14 @@ sonar.python.version=3.14
 sonar.cpd.maxDensity=3
 
 # Coverage - disabled for quality gate evaluation
-sonar.coverage.exclusions=**/*
-sonar.qualitygate.coverage.enabled=false
+# sonar.coverage.exclusions=**/*
+# sonar.qualitygate.coverage.enabled=false
+sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.xml
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity
 sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=*
+# sonar.issue.ignore.multicriteria.e1.ruleKey=*
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 
 # Vulnerability severity configuration


### PR DESCRIPTION
- CI: enable full clone, setup Go, install gocover-cobertura and run tests to produce Cobertura XML for Sonar
- sonar-project: point go coverage report to cookiefarm/server/coverage
- justfile: update test task to generate coverage.xml and include ./...
- docs: add gocover install note
