### PR TITLE
Use Go coverage.out and JSON test report for Sonar

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,15 +23,11 @@ jobs:
           go-version: 'stable'
           cache-dependency-path: cookiefarm/server/go.sum
 
-      - name: Install gocover-cobertura
-        run: go install github.com/boumenot/gocover-cobertura@latest
-
       - name: Run tests & generate coverage
         working-directory: cookiefarm/server
         run: |
           mkdir -p ./coverage
-          go test -coverprofile=./coverage/coverage.out -v ./...
-          gocover-cobertura < ./coverage/coverage.out > ./coverage/coverage.xml
+          go test work -coverprofile=./coverage/coverage.out -json -v ./... > coverage/test_output.json
 
       - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           sed -i 's|^server/|cookiefarm/server/|g' \
             cookiefarm/coverage/coverage.out
+          sed -i 's|^server/|cookiefarm/server/|g' \
+            cookiefarm/coverage/coverage.out
 
       - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,6 +29,11 @@ jobs:
           mkdir -p ./coverage
           go test work -coverprofile=./coverage/coverage.out -json -v ./... > ./coverage/test_output.json 2>&1 || true
 
+      - name: Fix coverage paths
+        run: |
+          sed -i 's|^server/|cookiefarm/server/|g' \
+            cookiefarm/server/coverage/coverage.out
+
       - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@master
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Fix coverage paths
         run: |
           sed -i 's|^server/|cookiefarm/server/|g' \
-            cookiefarm/server/coverage/coverage.out
+            cookiefarm/coverage/coverage.out
 
       - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-path: cookiefarm/server/go.sum
 
       - name: Run tests & generate coverage
-        working-directory: cookiefarm/server
+        working-directory: cookiefarm
         run: |
           mkdir -p ./coverage
           go test work -coverprofile=./coverage/coverage.out -json -v ./... > ./coverage/test_output.json 2>&1 || true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: cookiefarm/server
         run: |
           mkdir -p ./coverage
-          go test work -coverprofile=./coverage/coverage.out -json -v ./... > coverage/test_output.json
+          go test work -coverprofile=./coverage/coverage.out -json -v ./... > ./coverage/test_output.json 2>&1 || true
 
       - name: SonarQube Scan CookieFarm
         uses: SonarSource/sonarqube-scan-action@master

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -24,7 +24,7 @@ Need to install:
 - goreleaser (For building and releasing Go binaries)
 - [sqlc](https://docs.sqlc.dev/en/stable/overview/install.html) (For generating Go code from SQL queries) 
 - [gotestsum](https://github.com/gotestyourself/gotestsum) (For running Go tests better)
-- [gocover](go install github.com/boumenot/gocover-cobertura@latest) // For generating code coverage reports in Cobertura format for SonarQube
+
 ## Client
 
 - Python3.14

--- a/justfile
+++ b/justfile
@@ -183,7 +183,6 @@ server-test:
     --post-run-command "notify-send 'Test finished successfully' -a gotestsum -u normal" --format testname \
     -- work -coverprofile=./coverage/coverage.out -v ./... \
     && go tool cover -html=./coverage/coverage.out -o ./coverage/coverage.html \
-    && gocover-cobertura < ./coverage/coverage.out > ./coverage/coverage.xml \
     && xdg-open ./coverage/coverage.html
 
 # Start all the components for run mock tests mode for testing

--- a/justfile
+++ b/justfile
@@ -176,8 +176,8 @@ client-install: client-build
 
 # Test client binaries
 [group('test')]
-[working-directory('cookiefarm/server')]
-server-test:
+[working-directory('cookiefarm')]
+test:
     @mkdir -p ./coverage
     @gotestsum \
     --post-run-command "notify-send 'Test finished successfully' -a gotestsum -u normal" --format testname \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,9 +15,9 @@ sonar.go.tests.reportPaths=cookiefarm/coverage/test_output.json
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=*
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
+# sonar.issue.ignore.multicriteria=e1
+# sonar.issue.ignore.multicriteria.e1.ruleKey=*
+# sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 
 # Vulnerability severity configuration
 # Low impact vulnerabilities do not fail the quality gate

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,14 +10,14 @@ sonar.cpd.maxDensity=3
 # Coverage - disabled for quality gate evaluation
 # sonar.coverage.exclusions=**/*
 # sonar.qualitygate.coverage.enabled=false
-sonar.go.coverage.reportPaths=./cookiefarm/server/coverage/coverage.out
-sonar.go.tests.reportPaths=./cookiefarm/server/coverage/test_output.json
+sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.out
+sonar.go.tests.reportPaths=cookiefarm/server/coverage/test_output.json
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity
-# sonar.issue.ignore.multicriteria=e1
-# sonar.issue.ignore.multicriteria.e1.ruleKey=*
-# sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=*
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
 
 # Vulnerability severity configuration
 # Low impact vulnerabilities do not fail the quality gate

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,8 +10,8 @@ sonar.cpd.maxDensity=3
 # Coverage - disabled for quality gate evaluation
 # sonar.coverage.exclusions=**/*
 # sonar.qualitygate.coverage.enabled=false
-sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.out
-sonar.go.tests.reportPaths=cookiefarm/server/coverage/test_output.json
+sonar.go.coverage.reportPaths=./cookiefarm/server/coverage/coverage.out
+sonar.go.tests.reportPaths=./cookiefarm/server/coverage/test_output.json
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,8 @@ sonar.cpd.maxDensity=3
 # Coverage - disabled for quality gate evaluation
 # sonar.coverage.exclusions=**/*
 # sonar.qualitygate.coverage.enabled=false
-sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.xml
+sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.out
+sonar.go.tests.reportPaths=cookiefarm/server/coverage/test_output.json
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,8 +10,8 @@ sonar.cpd.maxDensity=3
 # Coverage - disabled for quality gate evaluation
 # sonar.coverage.exclusions=**/*
 # sonar.qualitygate.coverage.enabled=false
-sonar.go.coverage.reportPaths=cookiefarm/server/coverage/coverage.out
-sonar.go.tests.reportPaths=cookiefarm/server/coverage/test_output.json
+sonar.go.coverage.reportPaths=cookiefarm/coverage/coverage.out
+sonar.go.tests.reportPaths=cookiefarm/coverage/test_output.json
 
 # Issue severity thresholds
 # Only fail on new issues that are MEDIUM or higher severity

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=ByteTheCookies_CookieFarm_33543eea-e4db-4caa-a927-cceacf8b4cbf
 sonar.projectName=CookieFarm
-sonar.exclusions=**/demo/**/*
+sonar.exclusions=**/demo/**/*,**/*_test.go
 sonar.python.version=3.14
 
 # Quality Gate Configuration
@@ -22,3 +22,6 @@ sonar.go.tests.reportPaths=cookiefarm/coverage/test_output.json
 # Vulnerability severity configuration
 # Low impact vulnerabilities do not fail the quality gate
 sonar.qualitygate.ignoreSmallChanges=true
+
+# Tests
+sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
Remove gocover-cobertura install and conversion. Update CI workflow, justfile, sonar-project.properties, and docs.