### PR TITLE
Add login command to root with backcompatibilty to the old version

### DIFF
--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -76,6 +76,7 @@ func buildConfigCmd() *cobra.Command {
 	configCmd.AddCommand(resetConfigCmd)
 	configCmd.AddCommand(editConfigCmd)
 	configCmd.AddCommand(loginConfigCmd)
+	rootCmd.AddCommand(loginConfigCmd)
 	configCmd.AddCommand(logoutConfigCmd)
 	configCmd.AddCommand(showConfigCmd)
 


### PR DESCRIPTION
This pull request makes a small update to the command registration in the CLI application. The `loginConfigCmd` is now also registered as a root-level command, making it accessible directly from the root command in addition to being available under the `config` command.