### PR TITLE
List exploits from filesystem and update CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ yarn-error.log*
 next-env.d.ts
 .next
 !frontend/src/app/logs
-!.env.just
+.env.just

--- a/cookiefarm/client/cmd/exploit.go
+++ b/cookiefarm/client/cmd/exploit.go
@@ -215,8 +215,8 @@ func list(cmd *cobra.Command, args []string) {
 		return
 	} else {
 		var list strings.Builder
-		for pid, name := range res {
-			fmt.Fprintf(&list, "%s %d", name, pid)
+		for _, name := range res {
+			fmt.Fprintf(&list, "%s \n", name)
 		}
 
 		logger.Log.Info().Msg(list.String())

--- a/cookiefarm/client/internal/exploit/handler.go
+++ b/cookiefarm/client/internal/exploit/handler.go
@@ -17,7 +17,26 @@ func Cleanup(pid int) {
 	_ = ex.SaveState(path.Join(config.DefaultPath, "exploits.state"))
 }
 
-func List() (map[int]string, error) {
+func List() ([]string, error) {
+	files, err := os.ReadDir(path.Join(config.DefaultPath, "exploits"))
+	if err != nil {
+		return nil, err
+	}
+
+	exploit := make([]string, len(files))
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+		exploit = append(exploit, name)
+	}
+
+	return exploit, nil
+}
+
+func ListRunning() (map[int]string, error) {
 	return GetInstance().List(), nil
 }
 


### PR DESCRIPTION
Change List() to return []string and populate it by reading the exploits directory. Add ListRunning() to expose the running-instance map. Update the exploit list command to consume the new slice result. Also modify .gitignore to ignore .env.just instead of negating it.