### PR TITLE
Rename update command to edit and add listrun subcommand

### DIFF
--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -33,10 +33,10 @@ var resetConfigCmd = &cobra.Command{
 }
 
 var editConfigCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update client configuration",
+	Use:   "edit",
+	Short: "Edit client configuration",
 	Long:  `This command allows you to edit the client configuration interactively. It opens the configuration file in your default text editor, enabling you to make changes to settings such as server host, port, and other parameters.`, //nolint:revive
-	Run:   update,
+	Run:   edit,
 }
 
 var loginConfigCmd = &cobra.Command{
@@ -93,10 +93,10 @@ func reset(cmd *cobra.Command, args []string) {
 	logger.Log.Info().Msg("Configuration file reset successfully.")
 }
 
-func update(cmd *cobra.Command, args []string) {
+func edit(cmd *cobra.Command, args []string) {
 	cm := config.GetInstance()
 	if host == "localhost" && port == 8080 && username == "cookieguest" && !https {
-		logger.Log.Warn().Msg("All default args detected. Update skipped. For available options, run `ckc config update --help`")
+		logger.Log.Warn().Msg("All default args detected. Update skipped. For available options, run `ckc config edit --help`")
 		return
 	}
 
@@ -109,7 +109,7 @@ func update(cmd *cobra.Command, args []string) {
 }
 
 func login(cmd *cobra.Command, args []string) {
-	update(cmd, args)
+	edit(cmd, args)
 	sessionPath, err := LoginHandler(password)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Login failed")

--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -66,10 +66,7 @@ func buildConfigCmd() *cobra.Command {
 	editConfigCmd.Flags().StringVarP(&username, "username", "u", "cookieguest", "Username for authenticating to the server")
 	editConfigCmd.Flags().BoolVarP(&https, "https", "s", false, "Use HTTPS for secure communication with the server")
 
-	loginConfigCmd.Flags().StringVarP(&host, "host", "H", "localhost", "Server host to connect to")
-	loginConfigCmd.Flags().Uint16VarP(&port, "port", "p", 8080, "Server port to connect to")
 	loginConfigCmd.Flags().StringVarP(&username, "username", "u", "cookieguest", "Username for authenticating to the server")
-	loginConfigCmd.Flags().BoolVarP(&https, "https", "s", false, "Use HTTPS for secure communication with the server")
 	loginConfigCmd.Flags().StringVarP(&password, "password", "P", "", "Password for authenticating to the server")
 	loginConfigCmd.MarkFlagRequired("password")
 
@@ -109,7 +106,6 @@ func edit(cmd *cobra.Command, args []string) {
 }
 
 func login(cmd *cobra.Command, args []string) {
-	edit(cmd, args)
 	sessionPath, err := LoginHandler(password)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Login failed")

--- a/cookiefarm/client/cmd/exploit.go
+++ b/cookiefarm/client/cmd/exploit.go
@@ -64,9 +64,17 @@ var createCmd = &cobra.Command{
 // listCmd represents the list exploit command
 var listCmd = &cobra.Command{
 	Use:   "list",
+	Short: "List all exploits inside ~/.cookiefarm/exploits",
+	Long:  `This command lists all exploit created that are currently stored in the ~/.cookiefarm/exploits directory. It provides an overview of available exploits that can be edited or executed.`,
+	Run:   list,
+}
+
+// listRunningCmd represents the listr exploit command
+var listRunningCmd = &cobra.Command{
+	Use:   "listrun",
 	Short: "List all current running exploits",
 	Long:  "This command lists all currently running exploits that are registered in the local configuration.",
-	Run:   list,
+	Run:   listRunning,
 }
 
 // removeCmd represents the remove exploit command
@@ -104,6 +112,7 @@ func buildExploitCmd() *cobra.Command {
 	exploitCmd.AddCommand(createCmd)
 	exploitCmd.AddCommand(stopCmd)
 	exploitCmd.AddCommand(listCmd)
+	exploitCmd.AddCommand(listRunningCmd)
 	exploitCmd.AddCommand(removeCmd)
 	exploitCmd.AddCommand(submitCmd)
 
@@ -205,6 +214,21 @@ func create(cmd *cobra.Command, args []string) {
 		return
 	} else {
 		logger.Log.Info().Msg(res)
+	}
+}
+
+func listRunning(cmd *cobra.Command, args []string) {
+	res, err := exploit.ListRunning()
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("Error listing exploits")
+		return
+	} else {
+		var list strings.Builder
+		for pid, name := range res {
+			fmt.Fprintf(&list, "PID: %d, Name: %s \n", pid, name)
+		}
+
+		logger.Log.Info().Msg(list.String())
 	}
 }
 

--- a/cookiefarm/client/cmd/exploit.go
+++ b/cookiefarm/client/cmd/exploit.go
@@ -32,7 +32,7 @@ var (
 
 var exploitCmd = &cobra.Command{
 	Use:   "exploit",
-	Short: "Handling exploits and executing them in a loop",
+	Short: "Handling exploits and executing them",
 	Long:  `This command allows you to handle exploits (execute, create, etc.). You can specify the exploit path, service port, and other parameters.`,
 }
 


### PR DESCRIPTION
This pull request refines the configuration and exploit management commands for the client CLI, improving usability and adding new functionality. The most notable changes include renaming and refactoring the config edit command, enhancing exploit listing capabilities, and cleaning up command flag usage.

### Configuration command improvements

* Renamed the `update` command to `edit` for client configuration, updated its description, and refactored the handler function from `update` to `edit` for clarity and consistency. Also updated help messages to reflect the new command name. [[1]](diffhunk://#diff-799c55e86d41152eaf3a3e34e1433c04ac86dc52902c11fc36192fd5dee5ce10L36-R39) [[2]](diffhunk://#diff-799c55e86d41152eaf3a3e34e1433c04ac86dc52902c11fc36192fd5dee5ce10L96-R96)
* Removed redundant flag definitions from the `login` command that overlapped with the `edit` command, ensuring flags are only defined where needed.
* Removed the call to `update` from the `login` command to decouple login logic from configuration editing.

### Exploit command enhancements

* Added a new `list` subcommand to show all exploits stored in the `~/.cookiefarm/exploits` directory, and a new `listrun` subcommand to display all currently running exploits. Implemented the `listRunning` handler function for the new subcommand. [[1]](diffhunk://#diff-4600bfe7c3b9fa36582ab53758dc61c775c97bd72d76c8656ecc975a019fcb99R67-R77) [[2]](diffhunk://#diff-4600bfe7c3b9fa36582ab53758dc61c775c97bd72d76c8656ecc975a019fcb99R115) [[3]](diffhunk://#diff-4600bfe7c3b9fa36582ab53758dc61c775c97bd72d76c8656ecc975a019fcb99R220-R234)
* Updated the main `exploit` command’s description to remove mention of executing in a loop, reflecting its broader functionality.