### PR TITLE
Improve logging and parse output formatting

### DIFF
--- a/cookiefarm/client/internal/exploit/parse.go
+++ b/cookiefarm/client/internal/exploit/parse.go
@@ -2,6 +2,7 @@ package exploit
 
 import (
 	"errors"
+	"fmt"
 	"server/database"
 	"strings"
 	"time"
@@ -49,7 +50,8 @@ func (*Parser) parseStats(line string) (database.Flag, string, error) {
 	if err := json.Unmarshal([]byte(line), &out); err != nil {
 		return database.Flag{}, INVALID, err
 	}
-	msg := "Service: " + out.NameService
+	msg := fmt.Sprintf("Stats: Success: %d, Failed: %d, Total Flags: %d",
+		out.SuccessTeam, out.FailedTeam, out.TotalFlag)
 	return database.Flag{}, out.Status, errors.New(msg)
 }
 

--- a/cookiefarm/client/internal/exploit/run.go
+++ b/cookiefarm/client/internal/exploit/run.go
@@ -95,7 +95,6 @@ func (r *ExecutionResult) stream(
 		line := scanner.Text()
 
 		flag, status, err := parser.Parse(line)
-		logger.Log.Debug().Str("flag", flag.FlagCode).Str("status", status).Err(err).Msg("PARSED")
 		if err == nil && status == SUCCESS {
 			select {
 			case flags <- flag:
@@ -110,7 +109,9 @@ func (r *ExecutionResult) stream(
 		}
 
 		msg := formatMessage(line, err)
+
 		logger.Log.Info().Msgf("%s", msg)
+
 		if output != nil {
 			select {
 			case output <- msg:
@@ -123,8 +124,17 @@ func (r *ExecutionResult) stream(
 
 func formatMessage(raw string, err error) string {
 	if err != nil {
-		return err.Error()
+		errStr := err.Error()
+
+		if errStr == "Exploit test completed successfully" {
+			errStr = "\x1b[32m" + errStr + "\x1b[0m"
+		} else if errStr == "No flags found for NOP team" {
+			errStr = "\x1b[31m" + errStr + "\x1b[0m"
+		}
+
+		return errStr
 	}
+
 	return raw
 }
 

--- a/cookiefarm/client/internal/exploit/run.go
+++ b/cookiefarm/client/internal/exploit/run.go
@@ -126,9 +126,10 @@ func formatMessage(raw string, err error) string {
 	if err != nil {
 		errStr := err.Error()
 
-		if errStr == "Exploit test completed successfully" {
+		switch errStr {
+		case "Exploit test completed successfully":
 			errStr = "\x1b[32m" + errStr + "\x1b[0m"
-		} else if errStr == "No flags found for NOP team" {
+		case "No flags found for NOP team":
 			errStr = "\x1b[31m" + errStr + "\x1b[0m"
 		}
 

--- a/cookiefarm/client/internal/websockets/manager.go
+++ b/cookiefarm/client/internal/websockets/manager.go
@@ -121,7 +121,7 @@ func GetConnection() (*websocket.Conn, error) {
 
 	conn, err := tryToConnect(cm, maxAttempts, dialer)
 	if err == nil {
-		logger.Log.Info().Msg("Successfully connected to WebSocket")
+		logger.Log.Debug().Msg("Successfully connected to WebSocket")
 		monitor.SetStatus(StatusConnected)
 		return conn, nil
 	}
@@ -157,7 +157,7 @@ func WSHandleMessage(message []byte) error {
 		return err
 	}
 
-	logger.Log.Debug().Str("type", event.Type).Str("Payload", string(event.Payload)).Msg("Received event")
+	// logger.Log.Debug().Str("type", event.Type).Str("Payload", string(event.Payload)).Msg("Received event")
 
 	switch event.Type {
 	case ConfigEvent:

--- a/cookiefarm/client/internal/websockets/monitoring.go
+++ b/cookiefarm/client/internal/websockets/monitoring.go
@@ -44,7 +44,7 @@ func (m *ConnectionMonitor) SetConnection(conn *websocket.Conn) {
 		go m.startMonitoring()
 	}
 
-	logger.Log.Info().Msg("WebSocket connection registered with monitor")
+	logger.Log.Debug().Msg("WebSocket connection registered with monitor")
 }
 
 // RecordDisconnect records a disconnection event

--- a/cookiefarm/client/internal/websockets/submitter.go
+++ b/cookiefarm/client/internal/websockets/submitter.go
@@ -18,7 +18,7 @@ func startReader(conn *gorilla.Conn) {
 
 // Start initializes the submission loop to the cookiefarm server.
 func Start(flagsChan <-chan database.Flag) error {
-	logger.Log.Info().Msg("Starting submission loop to the cookiefarm server with websockets (websockets) ...")
+	logger.Log.Debug().Msg("Starting submission loop to the cookiefarm server with websockets (websockets) ...")
 
 	conn, err := GetConnection()
 	if err != nil {


### PR DESCRIPTION
Format stats output in parseStats using fmt and import fmt. Colorize specific parser messages ("Exploit test completed successfully" in green and "No flags found for NOP team" in red). Reduce log noise by demoting several Info logs to Debug and commenting out an overly verbose Debug log.