### PR TITLE
Change CONFIG_FILE type from boolean to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd CookieFarm
 # Server configuration
 DEBUG=false                   # Enable debug mode for verbose logging
 PASSWORD=SuperSecret  # Set a strong password for authentication
-CONFIG_FILE=true  # Set if the server takes the config from config.yml in the filesystem; otherwise, do not set the variable
+CONFIG_FILE=config.yml  # Set if the server takes the config from config.yml in the filesystem; otherwise, do not set the variable
 PORT=8080            # Define the port the server will listen on
 ```
 

--- a/cookiefarm/.env.example
+++ b/cookiefarm/.env.example
@@ -1,4 +1,4 @@
 PORT=8080
 PASSWORD=password
-CONFIG_FILE=true
+CONFIG_FILE=config.yml
 DEBUG=false

--- a/cookiefarm/cookiefarm.just
+++ b/cookiefarm/cookiefarm.just
@@ -24,7 +24,7 @@ server-build:
 [group('build')]
 [working-directory('cookiefarm')]
 server-run: server-build server-build-plugins
-    @{{ SERVER_BIN_DIR }}{{ PATHSEP }}{{ SERVER_BINARY_NAME }} -c -D
+    @{{ SERVER_BIN_DIR }}{{ PATHSEP }}{{ SERVER_BINARY_NAME }} -c config.yml -D
 
 # Run the server in development mode
 [group('build')]

--- a/cookiefarm/run.sh
+++ b/cookiefarm/run.sh
@@ -21,7 +21,7 @@ ARGS="-P ${PASSWORD}"
 ARGS="$ARGS -p ${PORT}"
 
 if [ -n "$CONFIG_FILE" ]; then
-    ARGS="$ARGS -c"
+    ARGS="$ARGS -c ${CONFIG_FILE}"
 fi
 
 if [ "$DEBUG" = "true" ]; then

--- a/cookiefarm/server/cmd/root.go
+++ b/cookiefarm/server/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "D", false, "Enable debug logging")
 	RootCmd.PersistentFlags().BoolVarP(&enablePprof, "pprof", "b", false, "Enable pprof for profiling")
 
-	RootCmd.PersistentFlags().BoolVarP(&config.UseConfigFile, "config", "c", false, "Use configuration file instead of web config")
+	RootCmd.PersistentFlags().StringVarP(&config.ConfigFile, "config", "c", "", "Use configuration file instead of web config")
 	RootCmd.PersistentFlags().StringVarP(&config.Password, "password", "P", "password", "Password for authentication")
 	RootCmd.PersistentFlags().StringVarP(&config.ServerPort, "port", "p", "8080", "Port for server")
 
@@ -124,9 +124,9 @@ func setupPassword() {
 }
 
 func loadConfig(runner *core.Runner) {
-	if config.UseConfigFile {
+	if config.ConfigFile != "" {
 		logger.Log.Info().Msg("Using file config...")
-		err := runner.LoadConfig(config.ConfigPath)
+		err := runner.LoadConfig(config.ConfigFile)
 		if err != nil {
 			logger.Log.Warn().Err(err).Msg("Config file not found or corrupted using web config")
 		}

--- a/cookiefarm/server/pkg/config/config.go
+++ b/cookiefarm/server/pkg/config/config.go
@@ -30,16 +30,15 @@ type ConfigManager struct {
 }
 
 var (
-	Debug         bool                                                                 // Global debug flag
-	UseConfigFile bool                                                                 // Use configuration file instead of web config
-	Password      string                                                               // Password for authentication
-	ServerPort    string                                                               // Port for server
-	Secret        = make([]byte, 32)                                                   // JWT secret key
-	Submit        func(string, string, []string) ([]protocols.ResponseProtocol, error) // Function to submit data
-	Cache         = true                                                               // Cache static file like css/js/image (If cache is enable more ram is used [default:true])
+	Debug      bool                                                                 // Global debug flag
+	ConfigFile string                                                               // Use configuration file instead of web config
+	Password   string                                                               // Password for authentication
+	ServerPort string                                                               // Port for server
+	Secret     = make([]byte, 32)                                                   // JWT secret key
+	Submit     func(string, string, []string) ([]protocols.ResponseProtocol, error) // Function to submit data
+	Cache      = true                                                               // Cache static file like css/js/image (If cache is enable more ram is used [default:true])
 )
 
 const (
-	ConfigPath   string = "config.yml" // Path to configuration file
-	DefaultLimit int    = 100          // Default maximum number of flags to retrieve in the view
+	DefaultLimit int = 100 // Default maximum number of flags to retrieve in the view
 )

--- a/docs/content/docs/architecture/server-internals.mdx
+++ b/docs/content/docs/architecture/server-internals.mdx
@@ -107,7 +107,7 @@ The server serves the React/Vite frontend from `cookiefarm/server/frontend`. Dat
 
 ## Operational Notes
 
-- `CONFIG_FILE=true` enables `config.yml` bootstrap.
+- `CONFIG_FILE=config.yml` enables `config.yml` bootstrap.
 - If web config is incomplete (`url_flag_checker` empty), submit API stores flags but cannot forward them to checker.
 - `flag_ttl` is in ticks, not absolute seconds.
 - CKP has no transport authentication or encryption; expose port `7777` only on trusted networks or through a controlled tunnel.

--- a/docs/content/docs/server/configuration.mdx
+++ b/docs/content/docs/server/configuration.mdx
@@ -17,14 +17,14 @@ Minimal example:
 ```text
 PORT=8080
 PASSWORD=SuperSecret
-CONFIG_FILE=true
+CONFIG_FILE=config.yml
 DEBUG=false
 ```
 
 Fields:
 - `PORT`: server HTTP port
 - `PASSWORD`: dashboard/client login password
-- `CONFIG_FILE`: if `true`, load config from file at boot
+- `CONFIG_FILE`: if `config.yml`, load config from file at boot
 - `DEBUG`: verbose logging
 
 ## `config.yml`
@@ -55,7 +55,7 @@ shared:
   nop_team: 0
   range_ip_teams: 20
   url_flag_ids: "http://127.0.0.1:5002/flagids"
-  flagids_format: "[service].[team].[id]"  
+  flagids_format: "[service].[team].[id]"
 ```
 
 ## Most important competition fields

--- a/install.sh
+++ b/install.sh
@@ -341,8 +341,11 @@ gum_ask_basic() {
     PORT="$(gum_input_int "Server PORT" "8080")"
     PASSWORD="$(gum_input "Server PASSWORD" --value "password" --placeholder "password")"
 
-    if gum_confirm --default "Use a config file (CONFIG_FILE)?"; then
-        CONFIG_FILE="true"
+    if gum_confirm "Use a config file (CONFIG_FILE)?"; then
+        CONFIG_FILE="$(gum_input "CONFIG_FILE path" --value "config.yml" --placeholder "config.yml")"
+        if [ -z "${CONFIG_FILE:-}" ]; then
+            CONFIG_FILE="config.yml"
+        fi
     else
         CONFIG_FILE="false"
     fi
@@ -370,7 +373,7 @@ gum_ask_config() {
     fi
     CFG_FILE="$dest"
 
-    [ "${CONFIG_FILE}" = "true" ] || return 0
+    [ "${CONFIG_FILE}" != "false" ] || return 0
 
     gum_section "  CONFIGURATION FILE  "
 

--- a/tech-docs/server/README.md
+++ b/tech-docs/server/README.md
@@ -98,7 +98,7 @@ Create a `.env` file with the following content:
 
 ```
 DEBUG=true
-CONFIG_FILE=true
+CONFIG_FILE=config.yml
 PASSWORD=SuperSecret
 PORT=8080
 ```


### PR DESCRIPTION
# Issue #175 

This pull request updates the way the server handles configuration files by switching from a boolean `CONFIG_FILE` flag to specifying the actual path of the configuration file (e.g., `config.yml`). This change affects environment variables, documentation, command-line arguments, and related scripts, improving clarity and flexibility for users who want to specify custom configuration files.

**Configuration handling improvements:**

* Changed `CONFIG_FILE` from a boolean flag to a string representing the config file path throughout the codebase, environment files, and documentation. Now, setting `CONFIG_FILE=config.yml` (or another path) enables file-based configuration; leaving it unset or set to `false` disables it. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R69) [[2]](diffhunk://#diff-16514d604cc6ea6c5242bc0b069e5be00581fa07031522fc24810a01b36480c3L3-R3) [[3]](diffhunk://#diff-1e503d9d9d1a07c0cebc84d641fe93f19be7637e318a6fef7f149dafee1c7c14L110-R110) [[4]](diffhunk://#diff-f95eb3180b95bc32e69226ed8460bacc96922f8dbd853ec7a785077f6b66b3beL20-R27) [[5]](diffhunk://#diff-df25a6af656d9fa29b32b05ad1da5156d83000d6fd68706c6e72108f9a645dd9L101-R101)

* Updated the server's command-line flags and internal config struct to use a string (`ConfigFile`) instead of a boolean (`UseConfigFile`). The server now checks if `ConfigFile` is non-empty to decide whether to load from file. [[1]](diffhunk://#diff-aee0ddfe5b460452ebc181bb2a51a8ba068ef57a2cc96056be4f61cdd1197b39L77-R77) [[2]](diffhunk://#diff-aee0ddfe5b460452ebc181bb2a51a8ba068ef57a2cc96056be4f61cdd1197b39L127-R129) [[3]](diffhunk://#diff-5c633d50f0710cde6de05d60272f6b1cd3c40bc3b90683d9869fda02321d00e6L34-R34) [[4]](diffhunk://#diff-5c633d50f0710cde6de05d60272f6b1cd3c40bc3b90683d9869fda02321d00e6L43)

**Script and tooling updates:**

* Modified `run.sh` and `cookiefarm.just` to pass the config file path as an argument when `CONFIG_FILE` is set, ensuring the server starts with the correct config file. [[1]](diffhunk://#diff-066a34fa26d1a78d89b4908329096fa240d39a4b91ad0148f8373fdc8122b547L24-R24) [[2]](diffhunk://#diff-f8448c9d6b910e5a9c2628a279f2ede4f10877a7f9196d9a8da9a4a97a964d8dL27-R27)

* Improved `install.sh` prompts to ask for a config file path instead of a yes/no for using a config file, defaulting to `config.yml` if left blank, and updated logic to match the new convention. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL344-R348) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL373-R376)