### PR TITLE
Update exploiter.just and publish new pypi test version

### DIFF
--- a/exploiter/exploiter.just
+++ b/exploiter/exploiter.just
@@ -80,13 +80,7 @@ py-publish-prod: py-build
 
 [group('python')]
 [working-directory('exploiter/python')]
-py-build-all:
-    @{{ ECHO_CMD }} "{{ CYAN }}[*] Step 1: TestPyPI{{ RESET }}"
-    @just py-publish-test
-
-    @{{ ECHO_CMD }} "{{ CYAN }}[*] Step 2: PyPI{{ RESET }}"
-    @just py-publish-prod
-
+py-build-all: py-publish-test py-publish-prod
     @{{ ECHO_CMD }} "{{ GREEN }}[+] All done!{{ RESET }}"
 
 # =========================

--- a/exploiter/exploiter.just
+++ b/exploiter/exploiter.just
@@ -54,7 +54,7 @@ py-clean:
 
 [group('python')]
 [working-directory('exploiter/python')]
-py-build:
+py-build: go-build py-sync-binaries
     @{{ ECHO_CMD }} "{{ CYAN }}[*] Building Python package (uv)...{{ RESET }}"
     @if ! command -v uv >/dev/null 2>&1; then echo "uv not found"; exit 1; fi
     @just py-clean
@@ -64,7 +64,7 @@ py-build:
 
 [group('python')]
 [working-directory('exploiter/python')]
-py-publish-test:
+py-publish-test: py-build
     @{{ ECHO_CMD }} "{{ CYAN }}[*] Publishing to TestPyPI...{{ RESET }}"
     @if ! command -v uv >/dev/null 2>&1; then echo "uv not found"; exit 1; fi
     @UV_PUBLISH_TOKEN={{ UV_TEST_PUBLISH_TOKEN }} uv publish --index testpypi
@@ -72,7 +72,7 @@ py-publish-test:
 
 [group('python')]
 [working-directory('exploiter/python')]
-py-publish-prod:
+py-publish-prod: py-build
     @{{ ECHO_CMD }} "{{ CYAN }}[*] Publishing to PyPI...{{ RESET }}"
     @if ! command -v uv >/dev/null 2>&1; then echo "uv not found"; exit 1; fi
     @UV_PUBLISH_TOKEN={{ UV_PUBLISH_TOKEN }} uv publish
@@ -80,22 +80,7 @@ py-publish-prod:
 
 [group('python')]
 [working-directory('exploiter/python')]
-py-build-test:
-    @just py-build
-    @just py-publish-test
-
-[group('python')]
-[working-directory('exploiter/python')]
-py-build-prod:
-    @just py-build
-    @just py-publish-prod
-
-[group('python')]
-[working-directory('exploiter/python')]
 py-build-all:
-    @{{ ECHO_CMD }} "{{ CYAN }}[*] Full pipeline (TestPyPI + PyPI)...{{ RESET }}"
-    @just py-build
-
     @{{ ECHO_CMD }} "{{ CYAN }}[*] Step 1: TestPyPI{{ RESET }}"
     @just py-publish-test
 
@@ -122,4 +107,4 @@ go-build:
 [group('python')]
 py-test-install:
     @{{ ECHO_CMD }} "{{ CYAN }}[*] Testing install from TestPyPI...{{ RESET }}"
-    @pip install -i https://test.pypi.org/simple cookiefarm
+    @pip install --upgrade -i https://test.pypi.org/simple cookiefarm

--- a/exploiter/python/pyproject.toml
+++ b/exploiter/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiefarm"
-version = "1.2.33"
+version = "1.2.34"
 description = "Python decorator for parallel exploit dispatch in Attack & Defense CTFs using the CookieFarm framework."
 readme = "README.md"
 authors = [{ name = "ByteTheCookies", email = "team@bytethecookies.org" }]

--- a/exploiter/python/uv.lock
+++ b/exploiter/python/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "cookiefarm"
-version = "1.2.33"
+version = "1.2.34"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
This pull request updates the Python package version and streamlines the build and publish process for the `cookiefarm` package in the `exploiter` project. The changes simplify the `just` build scripts by removing redundant tasks and ensuring that publish steps always depend on a fresh build. Additionally, the test installation step now ensures the latest package is installed during testing.

Build and publish process improvements:

* Made `py-build` depend on both `go-build` and `py-sync-binaries`, ensuring all dependencies are built before the Python package.
* Updated `py-publish-test` and `py-publish-prod` tasks to always run `py-build` first, guaranteeing that publishing uses the latest build.
* Removed redundant `py-build-test` and `py-build-prod` tasks to reduce duplication and simplify the workflow.
* Simplified `py-build-all` to only run the necessary publish steps, removing unnecessary rebuilds.

Version and testing updates:

* Bumped the package version from `1.2.33` to `1.2.34` in `pyproject.toml`.
* Changed the test install command to use `pip install --upgrade` to ensure the latest package is tested from TestPyPI.