### PR TITLE
Prepare release 1.3.0 with updated workflows and configurations

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,10 +1,10 @@
 name: Build & Push to GHCR
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    types: [ closed ]
-    branches: [ main ]
+    types: [closed]
+    branches: [main]
 concurrency:
   group: ghcr-build-main
   cancel-in-progress: true
@@ -21,20 +21,33 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for git describe
+
+      - name: Get Version
+        id: version
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_PAT }}
+
       - name: Build & Push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: ./Dockerfile
+          context: ./cookiefarm
+          file: ./cookiefarm/Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
           tags: |
             ${{ env.IMAGE_LATEST }}
             ${{ env.IMAGE_SHA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release (Go)
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.2.3
 
 permissions:
   contents: write # needed to write releases

--- a/cookiefarm/.goreleaser.yaml
+++ b/cookiefarm/.goreleaser.yaml
@@ -67,7 +67,7 @@ release:
   footer: |
     **Full Changelog**: https://github.com/ByteTheCookies/CookieFarm/compare/{{.PreviousTag}}...{{.Tag}}
 
-    Make by ByteTheCookies with ❤️ and cookies
+    Made by ByteTheCookies with ❤️ and cookies
 
 report_sizes: true
 


### PR DESCRIPTION
This pull request updates the release and publishing workflows to improve versioning, automate releases, and enhance metadata. The changes ensure that Docker images are versioned correctly, releases are triggered only for version tags, and release notes are more polished.

**Workflow and Release Process Improvements:**

* The Docker image publishing workflow now fetches all tags and determines the version dynamically using `git describe`, passing this version into the Docker build as a build argument. The Docker context and Dockerfile path are also updated to `./cookiefarm`. (.github/workflows/publish-ghcr.yml)
* The Go release workflow is updated to trigger only on version tags matching the pattern `v*.*.*` (e.g., `v1.2.3`), instead of every push to the `main` branch. (.github/workflows/release.yml)

**Release Metadata Enhancement:**

* The footer in the release notes is corrected from "Make by ByteTheCookies..." to "Made by ByteTheCookies..." for improved professionalism. (`cookiefarm/.goreleaser.yaml`)


> [!WARNING]
> I dont have yet fix the Pypi workflow so don't merge