### PR TITLE
Refactor config handling and improve timeout settings

### DIFF
--- a/cookiefarm/Dockerfile
+++ b/cookiefarm/Dockerfile
@@ -58,6 +58,4 @@ RUN touch /app/cookiefarm.db \
 
 USER vincenzino
 
-EXPOSE 8080
-
 ENTRYPOINT ["/bin/sh", "/app/run.sh"]

--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -62,9 +62,9 @@ var showConfigCmd = &cobra.Command{
 }
 
 func buildConfigCmd() *cobra.Command {
-	editConfigCmd.Flags().StringVarP(&host, "host", "H", "localhost", "Server host to connect to")
-	editConfigCmd.Flags().Uint16VarP(&port, "port", "p", 8080, "Server port to connect to")
-	editConfigCmd.Flags().StringVarP(&username, "username", "u", "cookieguest", "Username for authenticating to the server")
+	editConfigCmd.Flags().StringVarP(&host, "host", "H", "", "Server host to connect to")
+	editConfigCmd.Flags().Uint16VarP(&port, "port", "p", 0, "Server port to connect to")
+	editConfigCmd.Flags().StringVarP(&username, "username", "u", "", "Username for authenticating to the server")
 	editConfigCmd.Flags().BoolVarP(&https, "https", "s", false, "Use HTTPS for secure communication with the server")
 
 	loginConfigCmd.Flags().StringVarP(&username, "username", "u", "cookieguest", "Username for authenticating to the server")
@@ -93,14 +93,21 @@ func reset(cmd *cobra.Command, args []string) {
 
 func edit(cmd *cobra.Command, args []string) {
 	cm := config.GetInstance()
-	if host == "localhost" && port == 8080 && username == "cookieguest" && !https {
+	cm.Read()
+	if host == "" && port == 0 && username == "" {
 		logger.Log.Warn().Msg("All default args detected. Update skipped. For available options, run `ckc config edit --help`")
 		return
 	}
 
-	cm.SetHost(host)
-	cm.SetPort(port)
-	cm.SetUsername(username)
+	if host != "" {
+		cm.SetHost(host)
+	}
+	if port != 0 {
+		cm.SetPort(port)
+	}
+	if username != "" {
+		cm.SetUsername(username)
+	}
 	cm.SetHTTPS(https)
 
 	cm.WriteLocal()

--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -4,6 +4,7 @@ import (
 	"logger"
 	"os"
 	"path/filepath"
+	"sharedconfig"
 
 	"client/api"
 	"client/config"
@@ -108,7 +109,7 @@ func edit(cmd *cobra.Command, args []string) {
 }
 
 func login(cmd *cobra.Command, args []string) {
-	sessionPath, err := LoginHandler(password)
+	sessionPath, err := LoginHandler(username, password)
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Login failed")
 		return
@@ -131,27 +132,28 @@ func logout(cmd *cobra.Command, args []string) {
 }
 
 func show(cmd *cobra.Command, args []string) {
-	cm := config.GetInstance()
-	local, err := cm.ShowContent("client.yml")
+	local, err := config.ReadConfig[config.LocalConfig]("client.yml")
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Show configuration failed")
 		return
 	}
 
-	shared, err := cm.ShowContent("shared.yml")
+	shared, err := config.ReadConfig[sharedconfig.Shared]("shared.yml")
 	if err != nil {
 		logger.Log.Error().Err(err).Msg("Show configuration failed")
 		return
 	}
 
-	logger.Log.Info().Msg("Current configuration: \n```yaml\n" + local + "```")
-	logger.Log.Info().Msg("Shared configuration: \n```yaml\n" + shared + "```")
+	logger.Log.Info().Msg("Current client configuration:")
+	local.Print()
+	logger.Log.Info().Msg("Current shared configuration:")
+	shared.Print()
 }
 
-func LoginHandler(password string) (string, error) {
+func LoginHandler(username, password string) (string, error) {
 	cm := config.GetInstance()
-
-	err := api.Login(cm.GetUsername(), password)
+	cm.SetUsername(username)
+	err := api.Login(username, password)
 	if err != nil {
 		return "", err
 	}

--- a/cookiefarm/client/cmd/args.go
+++ b/cookiefarm/client/cmd/args.go
@@ -116,7 +116,6 @@ func login(cmd *cobra.Command, args []string) {
 	}
 
 	logger.Log.Info().Str("path", sessionPath).Msg("Session token stored.")
-
 	cm := config.GetInstance()
 	cm.WriteShared()
 }
@@ -152,7 +151,9 @@ func show(cmd *cobra.Command, args []string) {
 
 func LoginHandler(username, password string) (string, error) {
 	cm := config.GetInstance()
+	cm.Read()
 	cm.SetUsername(username)
+	cm.Get()
 	err := api.Login(username, password)
 	if err != nil {
 		return "", err

--- a/cookiefarm/client/cmd/exploit.go
+++ b/cookiefarm/client/cmd/exploit.go
@@ -255,8 +255,9 @@ func list(cmd *cobra.Command, args []string) {
 	fp.Styles.Cursor = lipgloss.NewStyle().Foreground(lipgloss.Color("#CDA157")).Bold(true)
 	fp.Styles.Selected = lipgloss.NewStyle().Foreground(lipgloss.Color("#CDA157")).Bold(true)
 	fp.Cursor = "🍪"
+	fp.AutoHeight = false
 
-	m := exploit.FilePicker{Filepicker: fp}
+	m := exploit.NewFilePicker(fp)
 	_, _ = tea.NewProgram(m).Run()
 }
 

--- a/cookiefarm/client/cmd/root.go
+++ b/cookiefarm/client/cmd/root.go
@@ -20,6 +20,8 @@ var whiteListCommand []string = []string{
 	"help",
 	"edit",
 	"reset",
+	"logout",
+	"login",
 }
 
 func configCheck(cm *config.ConfigManager) error {

--- a/cookiefarm/client/cmd/root.go
+++ b/cookiefarm/client/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"logger"
 	"os"
+	"slices"
 	"strings"
 
 	"client/api"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+var whiteListCommand []string = []string{
+	"completion",
+	"help",
+	"edit",
+	"reset",
+}
 
 func configCheck(cm *config.ConfigManager) error {
 	remoteCfg, err := api.GetConfig()
@@ -86,7 +94,7 @@ func buildCmd(useTUI *bool) *cobra.Command {
 		}
 
 		logger.Log.Debug().Msgf("Running command: %s", cmd.CalledAs())
-		if cmd.CalledAs() == "completion" || cmd.CalledAs() == "help" || cmd.CalledAs() == "edit" {
+		if slices.Contains(whiteListCommand, cmd.CalledAs()) {
 			return
 		}
 

--- a/cookiefarm/client/internal/api/http.go
+++ b/cookiefarm/client/internal/api/http.go
@@ -39,7 +39,7 @@ func getClient() *Client {
 		instance = &Client{
 			baseURL: baseURL,
 			http: &http.Client{
-				Timeout: 10 * time.Second,
+				Timeout: 1 * time.Second,
 			},
 		}
 	})

--- a/cookiefarm/client/internal/api/http.go
+++ b/cookiefarm/client/internal/api/http.go
@@ -39,7 +39,7 @@ func getClient() *Client {
 		instance = &Client{
 			baseURL: baseURL,
 			http: &http.Client{
-				Timeout: 1 * time.Second,
+				Timeout: 3 * time.Second,
 			},
 		}
 	})

--- a/cookiefarm/client/internal/exploit/filepicker.go
+++ b/cookiefarm/client/internal/exploit/filepicker.go
@@ -124,10 +124,7 @@ func (m FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		helpH := lipgloss.Height(m.help.View(m.keys))
 		statusH := lipgloss.Height(m.statusView())
 
-		pickerH := msg.Height - headerH - helpH - statusH - 2
-		if pickerH < 3 {
-			pickerH = 3
-		}
+		pickerH := max(msg.Height-headerH-helpH-statusH-2, 3)
 		m.Filepicker.SetHeight(pickerH)
 	case tea.KeyMsg:
 		switch {
@@ -166,7 +163,7 @@ func (m FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m FilePicker) headerView() string {
+func (FilePicker) headerView() string {
 	banner := strings.TrimRight(logger.GetBanner("File Picker"), "\n")
 	if banner == "" {
 		return ""

--- a/cookiefarm/client/internal/exploit/filepicker.go
+++ b/cookiefarm/client/internal/exploit/filepicker.go
@@ -9,12 +9,19 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/filepicker"
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 )
 
 type FilePicker struct {
 	Filepicker   filepicker.Model
 	SelectedFile string
+	keys         keyMap
+	help         help.Model
+	width        int
+	height       int
 	quitting     bool
 	err          error
 }
@@ -24,10 +31,71 @@ type (
 	editorFinishedMsg struct{ err error }
 )
 
+// keyMap defines the keybindings shown in the help menu.
+type keyMap struct {
+	Up    key.Binding
+	Down  key.Binding
+	Left  key.Binding
+	Right key.Binding
+	Open  key.Binding
+	Help  key.Binding
+	Quit  key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Help, k.Quit}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Up, k.Down, k.Left, k.Right},
+		{k.Open, k.Help, k.Quit},
+	}
+}
+
+var defaultKeys = keyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "move down"),
+	),
+	Left: key.NewBinding(
+		key.WithKeys("left", "h"),
+		key.WithHelp("←/h", "go back"),
+	),
+	Right: key.NewBinding(
+		key.WithKeys("right", "l"),
+		key.WithHelp("→/l", "enter dir"),
+	),
+	Open: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "open"),
+	),
+	Help: key.NewBinding(
+		key.WithKeys("?"),
+		key.WithHelp("?", "toggle help"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("q", "esc", "ctrl+c"),
+		key.WithHelp("q", "quit"),
+	),
+}
+
+func NewFilePicker(fp filepicker.Model) FilePicker {
+	return FilePicker{
+		Filepicker: fp,
+		keys:       defaultKeys,
+		help:       help.New(),
+	}
+}
+
 func openEditorCmd(path string) tea.Cmd {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
-		editor = "vim" // fallback
+		editor = "vi" // fallback
 	}
 	c := exec.Command(editor, path) //nolint:gosec
 	return tea.ExecProcess(c, func(err error) tea.Msg {
@@ -47,9 +115,25 @@ func (m FilePicker) Init() tea.Cmd {
 
 func (m FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.help.SetWidth(msg.Width)
+
+		headerH := lipgloss.Height(m.headerView())
+		helpH := lipgloss.Height(m.help.View(m.keys))
+		statusH := lipgloss.Height(m.statusView())
+
+		pickerH := msg.Height - headerH - helpH - statusH - 2
+		if pickerH < 3 {
+			pickerH = 3
+		}
+		m.Filepicker.SetHeight(pickerH)
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
+		switch {
+		case key.Matches(msg, m.keys.Help):
+			m.help.ShowAll = !m.help.ShowAll
+		case key.Matches(msg, m.keys.Quit):
 			m.quitting = true
 			return m, tea.Quit
 		}
@@ -82,29 +166,41 @@ func (m FilePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m FilePicker) headerView() string {
+	banner := strings.TrimRight(logger.GetBanner("File Picker"), "\n")
+	if banner == "" {
+		return ""
+	}
+	return lipgloss.NewStyle().PaddingLeft(2).Render(banner)
+}
+
+func (m FilePicker) statusView() string {
+	var status string
+	switch {
+	case m.err != nil:
+		status = m.Filepicker.Styles.DisabledFile.Render(m.err.Error())
+	case m.SelectedFile == "":
+		status = "Pick a file:"
+	default:
+		status = "Selected file: " + m.SelectedFile
+	}
+	return lipgloss.NewStyle().PaddingLeft(2).Render(status)
+}
+
 func (m FilePicker) View() tea.View {
 	if m.quitting {
 		return tea.NewView("")
 	}
 
-	banner := strings.TrimRight(logger.GetBanner("File Picker"), "\n")
-
-	var s strings.Builder
-	s.WriteString("\n  ")
-	if banner != "" {
-		s.WriteString(banner + "\n\n  ")
-	}
-	switch {
-	case m.err != nil:
-		s.WriteString(m.Filepicker.Styles.DisabledFile.Render(m.err.Error()))
-	case m.SelectedFile == "":
-		s.WriteString("Pick a file:")
-	default:
-		s.WriteString("Selected file: " + m.SelectedFile)
-	}
-
-	s.WriteString("\n\n" + m.Filepicker.View() + "\n")
-	v := tea.NewView(s.String())
+	v := tea.NewView(
+		lipgloss.JoinVertical(
+			lipgloss.Left,
+			m.headerView(),
+			m.Filepicker.View(),
+			m.statusView(),
+			m.help.View(m.keys),
+		),
+	)
 	v.AltScreen = true
 	return v
 }

--- a/cookiefarm/client/internal/exploit/go.mod
+++ b/cookiefarm/client/internal/exploit/go.mod
@@ -5,11 +5,11 @@ go 1.26.0
 require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.6
+	charm.land/lipgloss/v2 v2.0.2
 	github.com/bytedance/sonic v1.15.0
 )
 
 require (
-	charm.land/lipgloss/v2 v2.0.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect

--- a/cookiefarm/client/pkg/config/config.go
+++ b/cookiefarm/client/pkg/config/config.go
@@ -35,8 +35,8 @@ type ConfigManager struct {
 }
 
 func (l *LocalConfig) Print() {
-	println("Host:", l.Host)
-	println("Username:", l.Username)
-	println("Port:", l.Port)
-	println("HTTPS:", l.HTTPS)
+	println("Host:", l.Host)         //nolint:forbidigo
+	println("Username:", l.Username) //nolint:forbidigo
+	println("Port:", l.Port)         //nolint:forbidigo
+	println("HTTPS:", l.HTTPS)       //nolint:forbidigo
 }

--- a/cookiefarm/client/pkg/config/config.go
+++ b/cookiefarm/client/pkg/config/config.go
@@ -33,3 +33,10 @@ type RuntimeConfig struct {
 type ConfigManager struct {
 	state atomic.Value // *RuntimeConfig
 }
+
+func (l *LocalConfig) Print() {
+	println("Host:", l.Host)
+	println("Username:", l.Username)
+	println("Port:", l.Port)
+	println("HTTPS:", l.HTTPS)
+}

--- a/cookiefarm/client/pkg/config/manager.go
+++ b/cookiefarm/client/pkg/config/manager.go
@@ -201,6 +201,20 @@ func (*ConfigManager) Logout() (string, error) {
 	return "Logout successfully", nil
 }
 
+func ReadConfig[T any](filename string) (*T, error) {
+	content, err := os.ReadFile(filepath.Join(DefaultPath, filename))
+	if err != nil {
+		return nil, fmt.Errorf("error reading config: %w", err)
+	}
+
+	var cfg T
+	if err := yaml.Unmarshal(content, &cfg); err != nil {
+		return nil, fmt.Errorf("error unmarshaling config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
 func (*ConfigManager) ShowContent(filename string) (string, error) {
 	content, err := os.ReadFile(filepath.Join(DefaultPath, filename))
 	if err != nil {

--- a/cookiefarm/pkg/config/config.go
+++ b/cookiefarm/pkg/config/config.go
@@ -14,16 +14,16 @@ type Shared struct {
 
 func (cfg *Shared) Print() {
 	for service, port := range cfg.Services {
-		println("Service:", service, "Port:", port)
+		println("Service:", service, "Port:", port) //nolint:forbidigo
 	}
-	println("RegexFlag:", cfg.RegexFlag)
-	println("FormatIPTeams:", cfg.FormatIPTeams)
-	println("MyTeamID:", cfg.MyTeamID)
-	println("URLFlagIds:", cfg.URLFlagIds)
-	println("NOPTeam:", cfg.NOPTeam)
-	println("RangeIPTeams:", cfg.RangeIPTeams)
-	println("Configured:", cfg.Configured)
-	println("FlagIdsFormat:", cfg.FlagIdsFormat)
+	println("RegexFlag:", cfg.RegexFlag)         //nolint:forbidigo
+	println("FormatIPTeams:", cfg.FormatIPTeams) //nolint:forbidigo
+	println("MyTeamID:", cfg.MyTeamID)           //nolint:forbidigo
+	println("URLFlagIds:", cfg.URLFlagIds)       //nolint:forbidigo
+	println("NOPTeam:", cfg.NOPTeam)             //nolint:forbidigo
+	println("RangeIPTeams:", cfg.RangeIPTeams)   //nolint:forbidigo
+	println("Configured:", cfg.Configured)       //nolint:forbidigo
+	println("FlagIdsFormat:", cfg.FlagIdsFormat) //nolint:forbidigo
 }
 
 func (cfg *Shared) Set(newcfg Shared) {

--- a/cookiefarm/pkg/config/config.go
+++ b/cookiefarm/pkg/config/config.go
@@ -12,6 +12,20 @@ type Shared struct {
 	FlagIdsFormat string            `json:"flagids_format" yaml:"flagids_format"`   // Format string for generating flag IDs
 }
 
+func (cfg *Shared) Print() {
+	for service, port := range cfg.Services {
+		println("Service:", service, "Port:", port)
+	}
+	println("RegexFlag:", cfg.RegexFlag)
+	println("FormatIPTeams:", cfg.FormatIPTeams)
+	println("MyTeamID:", cfg.MyTeamID)
+	println("URLFlagIds:", cfg.URLFlagIds)
+	println("NOPTeam:", cfg.NOPTeam)
+	println("RangeIPTeams:", cfg.RangeIPTeams)
+	println("Configured:", cfg.Configured)
+	println("FlagIdsFormat:", cfg.FlagIdsFormat)
+}
+
 func (cfg *Shared) Set(newcfg Shared) {
 	*cfg = newcfg
 }

--- a/cookiefarm/pkg/protocols/faust.go
+++ b/cookiefarm/pkg/protocols/faust.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"models"
 	"net"
-	"protocols"
 	"strings"
 	"time"
+
+	"protocols"
 )
 
 func Submit(url string, teamToken string, flags []string) ([]protocols.ResponseProtocol, error) {

--- a/cookiefarm/pkg/protocols/faust.go
+++ b/cookiefarm/pkg/protocols/faust.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"models"
 	"net"
+	"protocols"
 	"strings"
 	"time"
-
-	"protocols"
 )
 
 func Submit(url string, teamToken string, flags []string) ([]protocols.ResponseProtocol, error) {
@@ -123,7 +122,7 @@ func matchFlag(line string, flagIndex map[string][]int) string {
 	return ""
 }
 
-func hasFlagPrefix(line string, flag string) bool {
+func hasFlagPrefix(line, flag string) bool {
 	rest, ok := strings.CutPrefix(line, flag)
 	return ok && (rest == "" || rest[0] == ' ' || rest[0] == '\t')
 }
@@ -139,7 +138,7 @@ func nextFlagIndex(matchedFlag string, flagIndex map[string][]int) (int, error) 
 	return idx, nil
 }
 
-func parseStatusAndMessage(line string, matchedFlag string) (string, string, error) {
+func parseStatusAndMessage(line, matchedFlag string) (string, string, error) {
 	rest := strings.TrimLeft(line[len(matchedFlag):], " \t")
 	parts := strings.Fields(rest)
 	if len(parts) == 0 {

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",

--- a/docs/content/docs/client/cli-reference.mdx
+++ b/docs/content/docs/client/cli-reference.mdx
@@ -25,7 +25,6 @@ Flags:
 - `-P, --password` (required)
 
 Note:
-- `ckc login` is also available as a top-level alias for this command.
 - Configure host/port/https with `ckc config edit` before login.
 
 ![ckc login example](/docs/login.png)

--- a/docs/content/docs/client/installation.mdx
+++ b/docs/content/docs/client/installation.mdx
@@ -12,7 +12,7 @@ description: Install the `ckc` client from the Python package `cookiefarm`.
 - Python 3.13+
 - `pip`
 
-## Recommended Installation (venv)
+## Installation (venv)
 
 ```bash
 python3 -m venv .venv

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -41,7 +41,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   return (
     <DocsPage toc={page.data.toc} tableOfContent={
       {
-        style: 'normal' // normal because clerk is broken in firefox based browser
+        style: 'normal' // `normal` because `clerk` is broken in firefox based browser
       }
     } full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>

--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -4,7 +4,7 @@ import { baseOptions } from '@/lib/layout.shared';
 
 export default function Layout({ children }: LayoutProps<'/docs'>) {
   return (
-    <DocsLayout tree={source.getPageTree()} {...baseOptions()}>
+    <DocsLayout tree={source.getPageTree()} {...baseOptions({ customNav: false })}>
       {children}
     </DocsLayout>
   );

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -109,3 +109,18 @@ html>body[data-scroll-locked] {
     margin-right: 0px !important;
     --removed-body-scroll-bar-size: 0px !important;
 }
+
+@media (width < 64rem) {
+    #nd-docs-layout {
+        --fd-header-height: calc(var(--spacing) * 14) !important;
+        --fd-sidebar-width: 0px !important;
+    }
+
+    #nd-docs-layout [data-sidebar-placeholder] {
+        display: none !important;
+    }
+
+    #nd-subnav {
+        display: flex !important;
+    }
+}

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -2,9 +2,22 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import { gitConfig } from './shared';
 import { Nav } from '@/app/(home)/page';
 
-export function baseOptions(): BaseLayoutProps {
+type BaseOptionsConfig = {
+  customNav?: boolean;
+};
+
+export function baseOptions({ customNav = true }: BaseOptionsConfig = {}): BaseLayoutProps {
   return {
-    nav: { component: <Nav /> },
+    nav: customNav
+      ? { component: <Nav /> }
+      : {
+        title: (
+          <span>
+            <span className="font-mono font-bold text-(--green)">CookieFarm</span>
+          </span>
+        ),
+        url: '/',
+      },
     themeSwitch: {
       enabled: false
     },

--- a/install.sh
+++ b/install.sh
@@ -645,7 +645,7 @@ else
     cd CookieFarm
 
     gum_spin "Downloading compose.yml..." \
-        wget -q -O compose.yml https://raw.githubusercontent.com/ByteTheCookies/CookieFarm/dev/cookiefarm/compose.yml
+        wget -q -O compose.yml https://raw.githubusercontent.com/ByteTheCookies/CookieFarm/main/cookiefarm/compose.yml
 
     gum_ask_basic
     write_env .      # → ./.env


### PR DESCRIPTION
# Some fix and hotfix for the 1.3.1

I want to release the version with all this fix this night, i am waiting all the tests by @vympel7 before do it

## AI SHIT

This pull request introduces improvements to the configuration handling and command logic in the client. The main focus is on enhancing how configuration is read and displayed, refactoring the login process to require a username, and improving command whitelisting. Additionally, the HTTP client timeout is reduced for faster failure in network operations. Below are the most important changes grouped by theme:

**Configuration Handling Improvements:**

* Added a generic `ReadConfig` function to simplify loading configuration files and updated the `show` command to use this function for both local and shared configs (`cookiefarm/client/pkg/config/manager.go`, `cookiefarm/client/cmd/args.go`). [[1]](diffhunk://#diff-7e7f945b10b1bd00ea221e456ac1f4f1aee25e3fd9e319f55ecbb0f1287eaef1R204-R217) [[2]](diffhunk://#diff-799c55e86d41152eaf3a3e34e1433c04ac86dc52902c11fc36192fd5dee5ce10L134-R156)
* Implemented `Print` methods for both `LocalConfig` and `Shared` types to provide structured output of configuration values (`cookiefarm/client/pkg/config/config.go`, `cookiefarm/pkg/config/config.go`). [[1]](diffhunk://#diff-cdb335cfef001e52db38adcf4b4a9c86297dae686bc1cae884e9910133c06174R36-R42) [[2]](diffhunk://#diff-18f2337e1d2f9f89b514276ad7decfa62ff137b8726199420b5ca24c975dd5bdR15-R28)

**Command Logic and Usability:**

* Refactored the login process so that `LoginHandler` and the `login` command now require a username argument, improving clarity and flexibility (`cookiefarm/client/cmd/args.go`). [[1]](diffhunk://#diff-799c55e86d41152eaf3a3e34e1433c04ac86dc52902c11fc36192fd5dee5ce10L111-R112) [[2]](diffhunk://#diff-799c55e86d41152eaf3a3e34e1433c04ac86dc52902c11fc36192fd5dee5ce10L134-R156)
* Introduced a `whiteListCommand` slice and updated command checking logic to use it, making the code more maintainable and easier to extend for whitelisted commands (`cookiefarm/client/cmd/root.go`). [[1]](diffhunk://#diff-9e5fb06a708e582c7901bf014d77b54b371015457363cc0d36f037543953d6e5R18-R24) [[2]](diffhunk://#diff-9e5fb06a708e582c7901bf014d77b54b371015457363cc0d36f037543953d6e5L89-R97)

**Networking:**

* Reduced the default HTTP client timeout from 10 seconds to 1 second to improve responsiveness in case of network issues (`cookiefarm/client/internal/api/http.go`).

**Documentation:**

* Minor documentation updates to clarify installation instructions and remove a redundant note about the `ckc login` alias (`docs/content/docs/client/installation.mdx`, `docs/content/docs/client/cli-reference.mdx`). [[1]](diffhunk://#diff-5d22ad44273d0b1af525e083e632a297096603f0579c4455e0063ff383a9f354L15-R15) [[2]](diffhunk://#diff-6224f64ab59dfd01511eb566c375d78725d06090af2fd783dab669ce3dbbec8fL28)