### PR TITLE
Bump version to 1.3.5 and remove hardcoded debug secret

### DIFF
--- a/cookiefarm/server/api/auth.go
+++ b/cookiefarm/server/api/auth.go
@@ -20,8 +20,6 @@ func InitSecret() ([]byte, error) {
 	if _, err := rand.Read(secret); err != nil {
 		logger.Log.Fatal().Err(err).Msg("failed to generate secret")
 	}
-	secret = []byte("mysecretkey") // Replace with your actual secret key
-
 	return secret, nil
 }
 

--- a/exploiter/python/pyproject.toml
+++ b/exploiter/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cookiefarm"
-version = "1.3.2.4"
+version = "1.3.5"
 description = "Python decorator for parallel exploit dispatch in Attack & Defense CTFs using the CookieFarm framework."
 readme = "README.md"
 authors = [{ name = "ByteTheCookies", email = "team@bytethecookies.org" }]


### PR DESCRIPTION
This pull request includes a version bump for the Python `cookiefarm` package and a security improvement in the Go server authentication code. The most important changes are summarized below:

Version Update:
* Updated the `cookiefarm` Python package version to `1.3.5` in `pyproject.toml`.

Security Improvements:
* Removed the hardcoded secret key assignment in the `InitSecret` function in `auth.go`, ensuring that secrets are now securely generated using `rand.Read`.